### PR TITLE
feat: add PHP language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Options:
 | Go         | `.go`                         | tree-sitter  |
 | Java       | `.java`                       | tree-sitter  |
 | Scala      | `.scala`, `.sc`               | tree-sitter  |
+| PHP        | `.php`, `.phtml`              | tree-sitter  |
 | SQL        | `.sql`                        | regex        |
 
 Languages with tree-sitter support produce full symbol tables (functions, classes, methods, callers, variables). SQL uses regex fallbacks for variable and definition detection. All file types appear in the file tree and are searchable via peek/grep.

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
+ "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-scala",
@@ -1288,6 +1289,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f066e94e9272cfe4f1dcb07a1c50c66097eca648f2d7233d299c8ae9ed8c130c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-python"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,6 +32,7 @@ tree-sitter-javascript = "0.25"
 tree-sitter-go = "0.25"
 tree-sitter-java = "0.23"
 tree-sitter-scala = "0.24"
+tree-sitter-php = "0.23"
 
 # Concurrency
 dashmap = "6"

--- a/server/src/index/file_entry.rs
+++ b/server/src/index/file_entry.rs
@@ -15,6 +15,7 @@ pub enum Language {
     C,
     Cpp,
     Ruby,
+    Php,
     Shell,
     Markdown,
     Json,
@@ -39,6 +40,7 @@ impl Language {
             "c" | "h" => Language::C,
             "cpp" | "cc" | "cxx" | "hpp" | "hxx" | "hh" => Language::Cpp,
             "rb" => Language::Ruby,
+            "php" | "phtml" => Language::Php,
             "sh" | "bash" | "zsh" | "fish" => Language::Shell,
             "md" | "mdx" => Language::Markdown,
             "json" | "jsonc" => Language::Json,
@@ -63,7 +65,7 @@ impl Language {
         matches!(
             self,
             Language::Rust | Language::Python | Language::TypeScript | Language::JavaScript | Language::Go
-            | Language::Java | Language::Scala
+            | Language::Java | Language::Scala | Language::Php
         )
     }
 }

--- a/server/src/ops/symbol_ops.rs
+++ b/server/src/ops/symbol_ops.rs
@@ -359,6 +359,12 @@ fn is_test_symbol(sym: &Symbol) -> bool {
         Language::Scala => {
             sym.file.contains("Spec") || sym.file.contains("Test") || sym.file.contains("/test/")
         }
+        Language::Php => {
+            sym.name.starts_with("test")
+                || sym.file.ends_with("Test.php")
+                || sym.file.contains("/tests/")
+                || sym.file.contains("/Tests/")
+        }
         Language::Sql => false,
         _ => false,
     }

--- a/server/src/symbols/queries/mod.rs
+++ b/server/src/symbols/queries/mod.rs
@@ -1,5 +1,6 @@
 pub mod go;
 pub mod java;
+pub mod php;
 pub mod python;
 pub mod rust;
 pub mod scala;
@@ -17,6 +18,7 @@ pub fn get_language_config(lang: Language) -> Option<LanguageConfig> {
         Language::Go => Some(go::config()),
         Language::Java => Some(java::config()),
         Language::Scala => Some(scala::config()),
+        Language::Php => Some(php::config()),
         _ => None,
     }
 }

--- a/server/src/symbols/queries/php.rs
+++ b/server/src/symbols/queries/php.rs
@@ -1,0 +1,72 @@
+use super::{LanguageConfig, TestPattern};
+
+pub const SYMBOLS_QUERY: &str = r#"
+(function_definition
+  name: (name) @function.name) @function.def
+
+(method_declaration
+  name: (name) @method.name) @method.def
+
+(class_declaration
+  name: (name) @class.name) @class.def
+
+(interface_declaration
+  name: (name) @interface.name) @interface.def
+
+(trait_declaration
+  name: (name) @trait.name) @trait.def
+
+(enum_declaration
+  name: (name) @enum.name) @enum.def
+
+(const_declaration
+  (const_element
+    (name) @const.name)) @const.def
+"#;
+
+pub const CALLERS_QUERY: &str = r#"
+(function_call_expression
+  function: (name) @callee)
+
+(member_call_expression
+  name: (name) @callee)
+
+(scoped_call_expression
+  name: (name) @callee)
+"#;
+
+pub const VARIABLES_QUERY: &str = r#"
+(simple_parameter
+  name: (variable_name (name) @var.name))
+
+(property_promotion_parameter
+  name: (variable_name (name) @var.name))
+
+(variadic_parameter
+  name: (variable_name (name) @var.name))
+
+(assignment_expression
+  left: (variable_name (name) @var.name))
+
+(foreach_statement
+  (variable_name (name) @var.name))
+
+(catch_clause
+  (variable_name (name) @var.name))
+
+(static_variable_declaration
+  (variable_name (name) @var.name))
+"#;
+
+pub fn config() -> LanguageConfig {
+    LanguageConfig {
+        language: tree_sitter_php::LANGUAGE_PHP.into(),
+        symbols_query: SYMBOLS_QUERY,
+        callers_query: CALLERS_QUERY,
+        variables_query: VARIABLES_QUERY,
+        test_patterns: vec![
+            TestPattern::FunctionPrefix("test"),
+            TestPattern::Attribute("Test"),
+        ],
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                            
                                                                                                                                                                                        
  Adds PHP support via `tree-sitter-php`, completing the gap for codebases                                                                                                              
  that mix PHP with the already-supported languages.                                                                                                                                    
                                                                                                                                                                                        
  ## What's covered                                                                                                                                                                     
                                                                                                                                                                                        
  **Symbols**                                                                                                                                                                           
  - Functions and methods                                                                                                                                                               
  - Classes, interfaces, traits, enums (PHP 8.1+)                                                                                                                                       
  - Constants, both file-level and class-level (the same `const_declaration`                                                                                                            
    node in `tree-sitter-php` covers both — there is no separate                                                                                                                        
    `class_const_declaration` node in the 0.23 grammar)                                                                                                                                 
                                                                                                                                                                                        
  **Callers** — three call forms:                                                                                                                                                       
  - `foo()` (`function_call_expression`)                                                                                                                                                
  - `$obj->method()` (`member_call_expression`)             
  - `Class::method()` (`scoped_call_expression`)                                                                                                                                        
   
  **Local variables**                                                                                                                                                                   
  - Function parameters (`simple_parameter`)                
  - PHP 8 constructor property promotion (`property_promotion_parameter`)
  - Variadic parameters `...$args` (`variadic_parameter`)                                                                                                                               
  - Assignments (`assignment_expression`)
  - `foreach (...) as $x` (`foreach_statement`)                                                                                                                                         
  - `catch (Exception $e)` (`catch_clause`)                                                                                                                                             
  - `static $x = ...` inside functions (`static_variable_declaration`)
                                                                                                                                                                                        
  **Test detection (`is_test_symbol`)** — PHPUnit conventions:                                                                                                                          
  - methods starting with `test*`
  - files ending in `Test.php`                                                                                                                                                          
  - files under `/tests/` or `/Tests/`                      
                                                                                                                                                                                        
  ## Files changed
                                                                                                                                                                                        
  - `server/Cargo.toml` / `Cargo.lock` — add `tree-sitter-php = "0.23"`                                                                                                                 
  - `server/src/index/file_entry.rs` — `Language::Php`, `.php` / `.phtml`
    extensions, `has_tree_sitter_support()` arm                                                                                                                                         
  - `server/src/symbols/queries/mod.rs` — register `php::config()`                                                                                                                      
  - `server/src/symbols/queries/php.rs` — new file (symbols / callers /
    variables queries + config)                                                                                                                                                         
  - `server/src/ops/symbol_ops.rs` — PHPUnit test detection 
  - `README.md` — new row in the Supported Languages table                                                                                                                              
                                                                                                                                                                                        
  ## Test plan
                                                                                                                                                                                        
  - [x] `cargo build --release` and `cargo check` pass cleanly
  - [x] Synthetic fixture exercises every query node above and extracts
        the expected symbols and variables                                                                                                                                              
  - [x] End-to-end run against a large internal PHP application                                                                                                                         
        (~20k PHP files): **164,717 symbols** extracted in ~3 min, no                                                                                                                   
        query errors. Distribution: 6,410 methods · 1,114 constants ·                                                                                                                   
        1,107 classes · 30 interfaces · 29 traits · 9 enums · 11 free                                                                                                                   
        functions.                                                                                                                                                                      
  - [x] Endpoints verified: `/symbols`, `/symbols/search`,  
        `/symbols/callers`, `/symbols/implementation`, `/symbols/variables`,                                                                                                            
        `/symbols/tests`, `/grep`                           
  - [x] Existing language support unaffected                                                                                                                                            
                                                                                                                                                                                        
  ## Disclaimer
                                                                                                                                                                                        
  Claude Code assisted with the tree-sitter queries. Every change was
  inspected manually and validated against a real PHP codebase before
  submission.    