### PR TITLE
Add Elixir support on upstream main

### DIFF
--- a/.codex/coderlm/coderlm_cli.py
+++ b/.codex/coderlm/coderlm_cli.py
@@ -1,0 +1,696 @@
+#!/usr/bin/env python3
+"""CLI wrapper for the coderlm-server API.
+
+Manages session state and provides clean commands for codebase exploration.
+All state is cached in .claude/coderlm_state/session.json relative to cwd.
+
+Two modes of operation:
+  1. Individual commands:  python3 coderlm_cli.py search MyFunction
+  2. Batch CLI commands:   python3 coderlm_cli.py batch --commands "search X\nimpl X --file Y"
+  3. Python REPL exec:     python3 coderlm_cli.py exec --code "search('X'); impl_('X', 'Y')"
+
+Usage:
+  python3 coderlm_cli.py init [--port PORT] [--cwd PATH]
+  python3 coderlm_cli.py search QUERY [--limit N] [--file FILE]
+  python3 coderlm_cli.py impl SYMBOL --file FILE
+  python3 coderlm_cli.py callers SYMBOL --file FILE [--limit N]
+  python3 coderlm_cli.py tests SYMBOL --file FILE [--limit N]
+  python3 coderlm_cli.py grep PATTERN [--max-matches N] [--scope all|code] [--file FILE]
+  python3 coderlm_cli.py peek FILE [--start N] [--end N]
+  python3 coderlm_cli.py symbols [--kind KIND] [--file FILE] [--limit N]
+  python3 coderlm_cli.py structure [--depth N]
+  python3 coderlm_cli.py variables FUNCTION --file FILE
+  python3 coderlm_cli.py batch --commands "cmd1\\ncmd2\\ncmd3"
+  python3 coderlm_cli.py exec --code "search('X'); impl_('X', 'file.py')"
+  python3 coderlm_cli.py status
+  python3 coderlm_cli.py cleanup
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+STATE_DIR = Path(os.environ.get("CODERLM_STATE_DIR", ".claude/coderlm_state"))
+STATE_FILE = STATE_DIR / "session.json"
+
+
+def _load_state() -> dict:
+    if not STATE_FILE.exists():
+        return {}
+    with STATE_FILE.open() as f:
+        return json.load(f)
+
+
+def _save_state(state: dict) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    with STATE_FILE.open("w") as f:
+        json.dump(state, f, indent=2)
+
+
+def _clear_state() -> None:
+    if STATE_FILE.exists():
+        STATE_FILE.unlink()
+
+
+def _base_url(state: dict) -> str:
+    host = state.get("host", "127.0.0.1")
+    port = state.get("port", 3000)
+    return f"http://{host}:{port}/api/v1"
+
+
+def _session_id(state: dict) -> str:
+    sid = state.get("session_id")
+    if not sid:
+        print("ERROR: No active session. Run: coderlm_cli.py init", file=sys.stderr)
+        sys.exit(1)
+    return sid
+
+
+def _request(
+    method: str,
+    url: str,
+    data: dict | None = None,
+    headers: dict | None = None,
+    timeout: int = 30,
+    exit_on_error: bool = True,
+) -> dict:
+    hdrs = headers or {}
+    body = None
+    if data is not None:
+        body = json.dumps(data).encode("utf-8")
+        hdrs["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=body, headers=hdrs, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            return json.loads(raw) if raw.strip() else {}
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode("utf-8", errors="replace")
+        try:
+            err = json.loads(body_text)
+        except json.JSONDecodeError:
+            err = {"error": body_text, "status": e.code}
+
+        if e.code == 410:
+            _clear_state()
+            if exit_on_error:
+                print("ERROR: Project was evicted from server. Run: coderlm_cli.py init",
+                      file=sys.stderr)
+                sys.exit(1)
+            return err
+
+        if exit_on_error:
+            print(json.dumps(err, indent=2))
+            sys.exit(1)
+        return err
+    except urllib.error.URLError as e:
+        err = {"error": f"Cannot connect to coderlm-server: {e.reason}"}
+        if exit_on_error:
+            print(
+                f"ERROR: Cannot connect to coderlm-server: {e.reason}\n"
+                f"Make sure the server is running: coderlm-server serve",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return err
+
+
+def _get(state: dict, path: str, params: dict | None = None) -> dict:
+    base = _base_url(state)
+    url = f"{base}{path}"
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        if clean:
+            url += "?" + urllib.parse.urlencode(clean)
+    return _request("GET", url, headers={"X-Session-Id": _session_id(state)})
+
+
+def _post(state: dict, path: str, data: dict) -> dict:
+    base = _base_url(state)
+    url = f"{base}{path}"
+    return _request("POST", url, data=data, headers={"X-Session-Id": _session_id(state)})
+
+
+def _safe_get(state: dict, path: str, params: dict | None = None) -> dict:
+    """Like _get but returns error dicts instead of calling sys.exit."""
+    sid = state.get("session_id")
+    if not sid:
+        return {"error": "No active session. Run: coderlm_cli.py init"}
+    base = _base_url(state)
+    url = f"{base}{path}"
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        if clean:
+            url += "?" + urllib.parse.urlencode(clean)
+    return _request("GET", url, headers={"X-Session-Id": sid}, exit_on_error=False)
+
+
+def _output(result: dict) -> None:
+    print(json.dumps(result, indent=2))
+
+
+# ── CLI Commands ─────────────────────────────────────────────────────
+
+
+def cmd_init(args: argparse.Namespace) -> None:
+    cwd = os.path.abspath(args.cwd or os.getcwd())
+    host = args.host or "127.0.0.1"
+    port = args.port or 3000
+    base = f"http://{host}:{port}/api/v1"
+
+    # Check server health first
+    try:
+        health = _request("GET", f"{base}/health")
+    except SystemExit:
+        return
+
+    # Create session
+    result = _request("POST", f"{base}/sessions", data={"cwd": cwd})
+    state = {
+        "session_id": result["session_id"],
+        "host": host,
+        "port": port,
+        "project": cwd,
+        "created_at": result.get("created_at", ""),
+    }
+    _save_state(state)
+
+    print(f"Session created: {result['session_id']}")
+    print(f"Project: {cwd}")
+    print(f"Server: {health.get('status', 'ok')} "
+          f"({health.get('projects', 0)} projects, "
+          f"{health.get('active_sessions', 0)} sessions)")
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    state = _load_state()
+    if not state:
+        host = args.host or "127.0.0.1"
+        port = args.port or 3000
+        base = f"http://{host}:{port}/api/v1"
+        result = _request("GET", f"{base}/health")
+        _output(result)
+        return
+
+    base = _base_url(state)
+    health = _request("GET", f"{base}/health")
+    info = {"server": health, "session": state}
+
+    sid = state.get("session_id")
+    if sid:
+        try:
+            session_info = _request("GET", f"{base}/sessions/{sid}")
+            info["session_details"] = session_info
+        except SystemExit:
+            info["session_details"] = "session may have expired"
+
+    _output(info)
+
+
+def cmd_structure(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {}
+    if args.depth is not None:
+        params["depth"] = args.depth
+    _output(_get(state, "/structure", params))
+
+
+def cmd_symbols(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {}
+    if args.kind:
+        params["kind"] = args.kind
+    if args.file:
+        params["file"] = args.file
+    if args.limit is not None:
+        params["limit"] = args.limit
+    _output(_get(state, "/symbols", params))
+
+
+def cmd_search(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"q": args.query}
+    if args.limit is not None:
+        params["limit"] = args.limit
+    if args.file is not None:
+        params["file"] = args.file
+    _output(_get(state, "/symbols/search", params))
+
+
+def cmd_impl(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"symbol": args.symbol, "file": args.file}
+    _output(_get(state, "/symbols/implementation", params))
+
+
+def cmd_callers(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"symbol": args.symbol, "file": args.file}
+    if args.limit is not None:
+        params["limit"] = args.limit
+    _output(_get(state, "/symbols/callers", params))
+
+
+def cmd_tests(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"symbol": args.symbol, "file": args.file}
+    if args.limit is not None:
+        params["limit"] = args.limit
+    _output(_get(state, "/symbols/tests", params))
+
+
+def cmd_variables(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"function": args.function, "file": args.file}
+    _output(_get(state, "/symbols/variables", params))
+
+
+def cmd_peek(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"file": args.file}
+    if args.start is not None:
+        params["start"] = args.start
+    if args.end is not None:
+        params["end"] = args.end
+    _output(_get(state, "/peek", params))
+
+
+def cmd_grep(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"pattern": args.pattern}
+    if args.max_matches is not None:
+        params["max_matches"] = args.max_matches
+    if args.context_lines is not None:
+        params["context_lines"] = args.context_lines
+    if args.scope is not None:
+        params["scope"] = args.scope
+    if args.file is not None:
+        params["file"] = args.file
+    _output(_get(state, "/grep", params))
+
+
+def cmd_chunks(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"file": args.file}
+    if args.size is not None:
+        params["size"] = args.size
+    if args.overlap is not None:
+        params["overlap"] = args.overlap
+    _output(_get(state, "/chunk_indices", params))
+
+
+def cmd_define_file(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/structure/define", {
+        "file": args.file,
+        "definition": args.definition,
+    }))
+
+
+def cmd_redefine_file(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/structure/redefine", {
+        "file": args.file,
+        "definition": args.definition,
+    }))
+
+
+def cmd_define_symbol(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/symbols/define", {
+        "symbol": args.symbol,
+        "file": args.file,
+        "definition": args.definition,
+    }))
+
+
+def cmd_redefine_symbol(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/symbols/redefine", {
+        "symbol": args.symbol,
+        "file": args.file,
+        "definition": args.definition,
+    }))
+
+
+def cmd_mark(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/structure/mark", {
+        "file": args.file,
+        "mark": args.type,
+    }))
+
+
+def cmd_history(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {}
+    if args.limit is not None:
+        params["limit"] = args.limit
+    _output(_get(state, "/history", params))
+
+
+def cmd_save_annotations(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/annotations/save", {}))
+
+
+def cmd_load_annotations(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/annotations/load", {}))
+
+
+def cmd_cleanup(args: argparse.Namespace) -> None:
+    state = _load_state()
+    if not state.get("session_id"):
+        print("No active session.")
+        return
+
+    base = _base_url(state)
+    sid = state["session_id"]
+    result = _request("DELETE", f"{base}/sessions/{sid}")
+    _clear_state()
+    print(f"Session {sid} deleted.")
+
+
+def cmd_batch(args: argparse.Namespace) -> None:
+    """Execute multiple CLI commands in one invocation."""
+    commands = args.commands
+    lines = commands.strip().split("\n")
+    any_failed = False
+    parser = build_parser()
+
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        print(f"=== {line} ===")
+        try:
+            tokens = shlex.split(line)
+            sub_args = parser.parse_args(tokens)
+            sub_args.func(sub_args)
+        except SystemExit as e:
+            if e.code != 0:
+                any_failed = True
+        except Exception as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            any_failed = True
+        print()
+
+    if any_failed:
+        sys.exit(1)
+
+
+# ── REPL Helper Functions (for exec --code) ──────────────────────────
+# These call the HTTP API directly (no subprocess). They print results
+# and return parsed data so they work naturally in exec'd Python code.
+
+
+def search(query: str, limit: int = 20, file: str | None = None):
+    """Find symbols by name. Returns list of symbol dicts."""
+    state = _load_state()
+    params = {"q": query, "limit": limit}
+    if file:
+        params["file"] = file
+    result = _safe_get(state, "/symbols/search", params)
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def impl_(symbol: str, file: str):
+    """Get full source code of a symbol. Returns source string or dict."""
+    state = _load_state()
+    result = _safe_get(state, "/symbols/implementation", {"symbol": symbol, "file": file})
+    print(json.dumps(result, indent=2) if isinstance(result, (dict, list)) else result)
+    return result
+
+
+def callers(symbol: str, file: str, limit: int = 50):
+    """Find call sites for a symbol. Returns list of caller dicts."""
+    state = _load_state()
+    result = _safe_get(state, "/symbols/callers", {"symbol": symbol, "file": file, "limit": limit})
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def tests(symbol: str, file: str, limit: int = 20):
+    """Find tests referencing a symbol. Returns list of test dicts."""
+    state = _load_state()
+    result = _safe_get(state, "/symbols/tests", {"symbol": symbol, "file": file, "limit": limit})
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def grep(pattern: str, max_matches: int = 50, scope: str = "all", file: str | None = None):
+    """Regex search across files. scope='code' skips comments/strings."""
+    state = _load_state()
+    params = {"pattern": pattern, "max_matches": max_matches, "scope": scope}
+    if file:
+        params["file"] = file
+    result = _safe_get(state, "/grep", params)
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def symbols(file: str | None = None, kind: str | None = None, limit: int = 100):
+    """List symbols. Optionally filter by file and/or kind."""
+    state = _load_state()
+    params = {"limit": limit}
+    if file:
+        params["file"] = file
+    if kind:
+        params["kind"] = kind
+    result = _safe_get(state, "/symbols", params)
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def peek_file(file: str, start: int = 0, end: int = 50):
+    """Read a range of lines from a file."""
+    state = _load_state()
+    result = _safe_get(state, "/peek", {"file": file, "start": start, "end": end})
+    print(json.dumps(result, indent=2) if isinstance(result, (dict, list)) else result)
+    return result
+
+
+def structure(detail: int = 0, depth: int = 0):
+    """Get project file tree. detail: 0-3, depth: 0=unlimited."""
+    state = _load_state()
+    params = {}
+    if depth:
+        params["depth"] = depth
+    result = _safe_get(state, "/structure", params)
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def variables_list(function: str, file: str):
+    """List local variables in a function."""
+    state = _load_state()
+    result = _safe_get(state, "/symbols/variables", {"function": function, "file": file})
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def cmd_exec(args: argparse.Namespace) -> None:
+    """Execute Python code with helper functions in scope."""
+    code = args.code
+    if not code:
+        print("ERROR: --code argument is required", file=sys.stderr)
+        sys.exit(1)
+
+    exec_globals = {
+        "__builtins__": __builtins__,
+        "search": search,
+        "impl_": impl_,
+        "callers": callers,
+        "tests": tests,
+        "grep": grep,
+        "symbols": symbols,
+        "peek_file": peek_file,
+        "structure": structure,
+        "variables_list": variables_list,
+        "json": json,
+    }
+
+    try:
+        exec(code, exec_globals)
+    except Exception as e:
+        print(f"ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ── Parser ────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="coderlm_cli",
+        description="CLI wrapper for coderlm-server API",
+    )
+
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    # init
+    p_init = sub.add_parser("init", help="Create a session for the current project")
+    p_init.add_argument("--cwd", help="Project directory (default: $PWD)")
+    p_init.add_argument("--host", default=None, help="Server host (default: 127.0.0.1)")
+    p_init.add_argument("--port", type=int, default=None, help="Server port (default: 3000)")
+    p_init.set_defaults(func=cmd_init)
+
+    # status
+    p_status = sub.add_parser("status", help="Show server and session status")
+    p_status.add_argument("--host", default=None)
+    p_status.add_argument("--port", type=int, default=None)
+    p_status.set_defaults(func=cmd_status)
+
+    # structure
+    p_struct = sub.add_parser("structure", help="Get project file tree")
+    p_struct.add_argument("--depth", type=int, default=None, help="Tree depth (0=unlimited)")
+    p_struct.set_defaults(func=cmd_structure)
+
+    # symbols
+    p_sym = sub.add_parser("symbols", help="List symbols")
+    p_sym.add_argument("--kind", help="Filter: function, method, class, struct, enum, trait, interface, constant, type, module")
+    p_sym.add_argument("--file", help="Filter by file path")
+    p_sym.add_argument("--limit", type=int, default=None)
+    p_sym.set_defaults(func=cmd_symbols)
+
+    # search
+    p_search = sub.add_parser("search", help="Search symbols by name")
+    p_search.add_argument("query", help="Search term")
+    p_search.add_argument("--limit", type=int, default=None)
+    p_search.add_argument("--file", help="Filter results to this file path")
+    p_search.set_defaults(func=cmd_search)
+
+    # impl
+    p_impl = sub.add_parser("impl", help="Get full source of a symbol")
+    p_impl.add_argument("symbol", help="Symbol name")
+    p_impl.add_argument("--file", required=True, help="File containing the symbol")
+    p_impl.set_defaults(func=cmd_impl)
+
+    # callers
+    p_callers = sub.add_parser("callers", help="Find call sites for a symbol")
+    p_callers.add_argument("symbol", help="Symbol name")
+    p_callers.add_argument("--file", required=True, help="File containing the symbol")
+    p_callers.add_argument("--limit", type=int, default=None)
+    p_callers.set_defaults(func=cmd_callers)
+
+    # tests
+    p_tests = sub.add_parser("tests", help="Find tests referencing a symbol")
+    p_tests.add_argument("symbol", help="Symbol name")
+    p_tests.add_argument("--file", required=True, help="File containing the symbol")
+    p_tests.add_argument("--limit", type=int, default=None)
+    p_tests.set_defaults(func=cmd_tests)
+
+    # variables
+    p_vars = sub.add_parser("variables", help="List local variables in a function")
+    p_vars.add_argument("function", help="Function name")
+    p_vars.add_argument("--file", required=True, help="File containing the function")
+    p_vars.set_defaults(func=cmd_variables)
+
+    # peek
+    p_peek = sub.add_parser("peek", help="Read a line range from a file")
+    p_peek.add_argument("file", help="File path")
+    p_peek.add_argument("--start", type=int, default=None, help="Start line (0-indexed)")
+    p_peek.add_argument("--end", type=int, default=None, help="End line (exclusive)")
+    p_peek.set_defaults(func=cmd_peek)
+
+    # grep
+    p_grep = sub.add_parser("grep", help="Regex search across all files")
+    p_grep.add_argument("pattern", help="Regex pattern")
+    p_grep.add_argument("--max-matches", type=int, default=None)
+    p_grep.add_argument("--context-lines", type=int, default=None)
+    p_grep.add_argument("--scope", choices=["all", "code"], default=None,
+                         help="Scope filter: 'all' (default) or 'code' (skip comments/strings)")
+    p_grep.add_argument("--file", help="Restrict grep to this file path")
+    p_grep.set_defaults(func=cmd_grep)
+
+    # chunks
+    p_chunks = sub.add_parser("chunks", help="Compute chunk boundaries for a file")
+    p_chunks.add_argument("file", help="File path")
+    p_chunks.add_argument("--size", type=int, default=None, help="Chunk size in bytes")
+    p_chunks.add_argument("--overlap", type=int, default=None, help="Overlap between chunks")
+    p_chunks.set_defaults(func=cmd_chunks)
+
+    # define-file
+    p_dfile = sub.add_parser("define-file", help="Set a description for a file")
+    p_dfile.add_argument("file", help="File path")
+    p_dfile.add_argument("definition", help="Human-readable description")
+    p_dfile.set_defaults(func=cmd_define_file)
+
+    # redefine-file
+    p_rdfile = sub.add_parser("redefine-file", help="Update a file description")
+    p_rdfile.add_argument("file", help="File path")
+    p_rdfile.add_argument("definition", help="Updated description")
+    p_rdfile.set_defaults(func=cmd_redefine_file)
+
+    # define-symbol
+    p_dsym = sub.add_parser("define-symbol", help="Set a description for a symbol")
+    p_dsym.add_argument("symbol", help="Symbol name")
+    p_dsym.add_argument("--file", required=True, help="File containing the symbol")
+    p_dsym.add_argument("definition", help="Human-readable description")
+    p_dsym.set_defaults(func=cmd_define_symbol)
+
+    # redefine-symbol
+    p_rdsym = sub.add_parser("redefine-symbol", help="Update a symbol description")
+    p_rdsym.add_argument("symbol", help="Symbol name")
+    p_rdsym.add_argument("--file", required=True, help="File containing the symbol")
+    p_rdsym.add_argument("definition", help="Updated description")
+    p_rdsym.set_defaults(func=cmd_redefine_symbol)
+
+    # mark
+    p_mark = sub.add_parser("mark", help="Tag a file with a category")
+    p_mark.add_argument("file", help="File path")
+    p_mark.add_argument("type", choices=["documentation", "ignore", "test", "config", "generated", "custom"],
+                         help="Mark type")
+    p_mark.set_defaults(func=cmd_mark)
+
+    # history
+    p_hist = sub.add_parser("history", help="Session command history")
+    p_hist.add_argument("--limit", type=int, default=None)
+    p_hist.set_defaults(func=cmd_history)
+
+    # save-annotations
+    p_save = sub.add_parser("save-annotations", help="Save annotations to disk (.coderlm/annotations.json)")
+    p_save.set_defaults(func=cmd_save_annotations)
+
+    # load-annotations
+    p_load = sub.add_parser("load-annotations", help="Load annotations from disk")
+    p_load.set_defaults(func=cmd_load_annotations)
+
+    # cleanup
+    p_clean = sub.add_parser("cleanup", help="Delete the current session")
+    p_clean.set_defaults(func=cmd_cleanup)
+
+    # batch
+    p_batch = sub.add_parser("batch", help="Run multiple CLI commands in one invocation")
+    p_batch.add_argument("--commands", required=True,
+                          help="Newline-separated CLI commands to execute sequentially")
+    p_batch.set_defaults(func=cmd_batch)
+
+    # exec
+    p_exec = sub.add_parser("exec", help="Execute Python code with coderlm helper functions")
+    p_exec.add_argument("--code", required=True,
+                         help="Python code with access to: search(), impl_(), callers(), tests(), grep(), symbols(), peek_file(), structure(), variables_list()")
+    p_exec.set_defaults(func=cmd_exec)
+
+    return p
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/coderlm/coderlm_cli.py
+++ b/.cursor/coderlm/coderlm_cli.py
@@ -1,0 +1,696 @@
+#!/usr/bin/env python3
+"""CLI wrapper for the coderlm-server API.
+
+Manages session state and provides clean commands for codebase exploration.
+All state is cached in .claude/coderlm_state/session.json relative to cwd.
+
+Two modes of operation:
+  1. Individual commands:  python3 coderlm_cli.py search MyFunction
+  2. Batch CLI commands:   python3 coderlm_cli.py batch --commands "search X\nimpl X --file Y"
+  3. Python REPL exec:     python3 coderlm_cli.py exec --code "search('X'); impl_('X', 'Y')"
+
+Usage:
+  python3 coderlm_cli.py init [--port PORT] [--cwd PATH]
+  python3 coderlm_cli.py search QUERY [--limit N] [--file FILE]
+  python3 coderlm_cli.py impl SYMBOL --file FILE
+  python3 coderlm_cli.py callers SYMBOL --file FILE [--limit N]
+  python3 coderlm_cli.py tests SYMBOL --file FILE [--limit N]
+  python3 coderlm_cli.py grep PATTERN [--max-matches N] [--scope all|code] [--file FILE]
+  python3 coderlm_cli.py peek FILE [--start N] [--end N]
+  python3 coderlm_cli.py symbols [--kind KIND] [--file FILE] [--limit N]
+  python3 coderlm_cli.py structure [--depth N]
+  python3 coderlm_cli.py variables FUNCTION --file FILE
+  python3 coderlm_cli.py batch --commands "cmd1\\ncmd2\\ncmd3"
+  python3 coderlm_cli.py exec --code "search('X'); impl_('X', 'file.py')"
+  python3 coderlm_cli.py status
+  python3 coderlm_cli.py cleanup
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+STATE_DIR = Path(os.environ.get("CODERLM_STATE_DIR", ".claude/coderlm_state"))
+STATE_FILE = STATE_DIR / "session.json"
+
+
+def _load_state() -> dict:
+    if not STATE_FILE.exists():
+        return {}
+    with STATE_FILE.open() as f:
+        return json.load(f)
+
+
+def _save_state(state: dict) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    with STATE_FILE.open("w") as f:
+        json.dump(state, f, indent=2)
+
+
+def _clear_state() -> None:
+    if STATE_FILE.exists():
+        STATE_FILE.unlink()
+
+
+def _base_url(state: dict) -> str:
+    host = state.get("host", "127.0.0.1")
+    port = state.get("port", 3000)
+    return f"http://{host}:{port}/api/v1"
+
+
+def _session_id(state: dict) -> str:
+    sid = state.get("session_id")
+    if not sid:
+        print("ERROR: No active session. Run: coderlm_cli.py init", file=sys.stderr)
+        sys.exit(1)
+    return sid
+
+
+def _request(
+    method: str,
+    url: str,
+    data: dict | None = None,
+    headers: dict | None = None,
+    timeout: int = 30,
+    exit_on_error: bool = True,
+) -> dict:
+    hdrs = headers or {}
+    body = None
+    if data is not None:
+        body = json.dumps(data).encode("utf-8")
+        hdrs["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=body, headers=hdrs, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            return json.loads(raw) if raw.strip() else {}
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode("utf-8", errors="replace")
+        try:
+            err = json.loads(body_text)
+        except json.JSONDecodeError:
+            err = {"error": body_text, "status": e.code}
+
+        if e.code == 410:
+            _clear_state()
+            if exit_on_error:
+                print("ERROR: Project was evicted from server. Run: coderlm_cli.py init",
+                      file=sys.stderr)
+                sys.exit(1)
+            return err
+
+        if exit_on_error:
+            print(json.dumps(err, indent=2))
+            sys.exit(1)
+        return err
+    except urllib.error.URLError as e:
+        err = {"error": f"Cannot connect to coderlm-server: {e.reason}"}
+        if exit_on_error:
+            print(
+                f"ERROR: Cannot connect to coderlm-server: {e.reason}\n"
+                f"Make sure the server is running: coderlm-server serve",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return err
+
+
+def _get(state: dict, path: str, params: dict | None = None) -> dict:
+    base = _base_url(state)
+    url = f"{base}{path}"
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        if clean:
+            url += "?" + urllib.parse.urlencode(clean)
+    return _request("GET", url, headers={"X-Session-Id": _session_id(state)})
+
+
+def _post(state: dict, path: str, data: dict) -> dict:
+    base = _base_url(state)
+    url = f"{base}{path}"
+    return _request("POST", url, data=data, headers={"X-Session-Id": _session_id(state)})
+
+
+def _safe_get(state: dict, path: str, params: dict | None = None) -> dict:
+    """Like _get but returns error dicts instead of calling sys.exit."""
+    sid = state.get("session_id")
+    if not sid:
+        return {"error": "No active session. Run: coderlm_cli.py init"}
+    base = _base_url(state)
+    url = f"{base}{path}"
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        if clean:
+            url += "?" + urllib.parse.urlencode(clean)
+    return _request("GET", url, headers={"X-Session-Id": sid}, exit_on_error=False)
+
+
+def _output(result: dict) -> None:
+    print(json.dumps(result, indent=2))
+
+
+# ── CLI Commands ─────────────────────────────────────────────────────
+
+
+def cmd_init(args: argparse.Namespace) -> None:
+    cwd = os.path.abspath(args.cwd or os.getcwd())
+    host = args.host or "127.0.0.1"
+    port = args.port or 3000
+    base = f"http://{host}:{port}/api/v1"
+
+    # Check server health first
+    try:
+        health = _request("GET", f"{base}/health")
+    except SystemExit:
+        return
+
+    # Create session
+    result = _request("POST", f"{base}/sessions", data={"cwd": cwd})
+    state = {
+        "session_id": result["session_id"],
+        "host": host,
+        "port": port,
+        "project": cwd,
+        "created_at": result.get("created_at", ""),
+    }
+    _save_state(state)
+
+    print(f"Session created: {result['session_id']}")
+    print(f"Project: {cwd}")
+    print(f"Server: {health.get('status', 'ok')} "
+          f"({health.get('projects', 0)} projects, "
+          f"{health.get('active_sessions', 0)} sessions)")
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    state = _load_state()
+    if not state:
+        host = args.host or "127.0.0.1"
+        port = args.port or 3000
+        base = f"http://{host}:{port}/api/v1"
+        result = _request("GET", f"{base}/health")
+        _output(result)
+        return
+
+    base = _base_url(state)
+    health = _request("GET", f"{base}/health")
+    info = {"server": health, "session": state}
+
+    sid = state.get("session_id")
+    if sid:
+        try:
+            session_info = _request("GET", f"{base}/sessions/{sid}")
+            info["session_details"] = session_info
+        except SystemExit:
+            info["session_details"] = "session may have expired"
+
+    _output(info)
+
+
+def cmd_structure(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {}
+    if args.depth is not None:
+        params["depth"] = args.depth
+    _output(_get(state, "/structure", params))
+
+
+def cmd_symbols(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {}
+    if args.kind:
+        params["kind"] = args.kind
+    if args.file:
+        params["file"] = args.file
+    if args.limit is not None:
+        params["limit"] = args.limit
+    _output(_get(state, "/symbols", params))
+
+
+def cmd_search(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"q": args.query}
+    if args.limit is not None:
+        params["limit"] = args.limit
+    if args.file is not None:
+        params["file"] = args.file
+    _output(_get(state, "/symbols/search", params))
+
+
+def cmd_impl(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"symbol": args.symbol, "file": args.file}
+    _output(_get(state, "/symbols/implementation", params))
+
+
+def cmd_callers(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"symbol": args.symbol, "file": args.file}
+    if args.limit is not None:
+        params["limit"] = args.limit
+    _output(_get(state, "/symbols/callers", params))
+
+
+def cmd_tests(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"symbol": args.symbol, "file": args.file}
+    if args.limit is not None:
+        params["limit"] = args.limit
+    _output(_get(state, "/symbols/tests", params))
+
+
+def cmd_variables(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"function": args.function, "file": args.file}
+    _output(_get(state, "/symbols/variables", params))
+
+
+def cmd_peek(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"file": args.file}
+    if args.start is not None:
+        params["start"] = args.start
+    if args.end is not None:
+        params["end"] = args.end
+    _output(_get(state, "/peek", params))
+
+
+def cmd_grep(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"pattern": args.pattern}
+    if args.max_matches is not None:
+        params["max_matches"] = args.max_matches
+    if args.context_lines is not None:
+        params["context_lines"] = args.context_lines
+    if args.scope is not None:
+        params["scope"] = args.scope
+    if args.file is not None:
+        params["file"] = args.file
+    _output(_get(state, "/grep", params))
+
+
+def cmd_chunks(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {"file": args.file}
+    if args.size is not None:
+        params["size"] = args.size
+    if args.overlap is not None:
+        params["overlap"] = args.overlap
+    _output(_get(state, "/chunk_indices", params))
+
+
+def cmd_define_file(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/structure/define", {
+        "file": args.file,
+        "definition": args.definition,
+    }))
+
+
+def cmd_redefine_file(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/structure/redefine", {
+        "file": args.file,
+        "definition": args.definition,
+    }))
+
+
+def cmd_define_symbol(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/symbols/define", {
+        "symbol": args.symbol,
+        "file": args.file,
+        "definition": args.definition,
+    }))
+
+
+def cmd_redefine_symbol(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/symbols/redefine", {
+        "symbol": args.symbol,
+        "file": args.file,
+        "definition": args.definition,
+    }))
+
+
+def cmd_mark(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/structure/mark", {
+        "file": args.file,
+        "mark": args.type,
+    }))
+
+
+def cmd_history(args: argparse.Namespace) -> None:
+    state = _load_state()
+    params = {}
+    if args.limit is not None:
+        params["limit"] = args.limit
+    _output(_get(state, "/history", params))
+
+
+def cmd_save_annotations(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/annotations/save", {}))
+
+
+def cmd_load_annotations(args: argparse.Namespace) -> None:
+    state = _load_state()
+    _output(_post(state, "/annotations/load", {}))
+
+
+def cmd_cleanup(args: argparse.Namespace) -> None:
+    state = _load_state()
+    if not state.get("session_id"):
+        print("No active session.")
+        return
+
+    base = _base_url(state)
+    sid = state["session_id"]
+    result = _request("DELETE", f"{base}/sessions/{sid}")
+    _clear_state()
+    print(f"Session {sid} deleted.")
+
+
+def cmd_batch(args: argparse.Namespace) -> None:
+    """Execute multiple CLI commands in one invocation."""
+    commands = args.commands
+    lines = commands.strip().split("\n")
+    any_failed = False
+    parser = build_parser()
+
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        print(f"=== {line} ===")
+        try:
+            tokens = shlex.split(line)
+            sub_args = parser.parse_args(tokens)
+            sub_args.func(sub_args)
+        except SystemExit as e:
+            if e.code != 0:
+                any_failed = True
+        except Exception as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            any_failed = True
+        print()
+
+    if any_failed:
+        sys.exit(1)
+
+
+# ── REPL Helper Functions (for exec --code) ──────────────────────────
+# These call the HTTP API directly (no subprocess). They print results
+# and return parsed data so they work naturally in exec'd Python code.
+
+
+def search(query: str, limit: int = 20, file: str | None = None):
+    """Find symbols by name. Returns list of symbol dicts."""
+    state = _load_state()
+    params = {"q": query, "limit": limit}
+    if file:
+        params["file"] = file
+    result = _safe_get(state, "/symbols/search", params)
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def impl_(symbol: str, file: str):
+    """Get full source code of a symbol. Returns source string or dict."""
+    state = _load_state()
+    result = _safe_get(state, "/symbols/implementation", {"symbol": symbol, "file": file})
+    print(json.dumps(result, indent=2) if isinstance(result, (dict, list)) else result)
+    return result
+
+
+def callers(symbol: str, file: str, limit: int = 50):
+    """Find call sites for a symbol. Returns list of caller dicts."""
+    state = _load_state()
+    result = _safe_get(state, "/symbols/callers", {"symbol": symbol, "file": file, "limit": limit})
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def tests(symbol: str, file: str, limit: int = 20):
+    """Find tests referencing a symbol. Returns list of test dicts."""
+    state = _load_state()
+    result = _safe_get(state, "/symbols/tests", {"symbol": symbol, "file": file, "limit": limit})
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def grep(pattern: str, max_matches: int = 50, scope: str = "all", file: str | None = None):
+    """Regex search across files. scope='code' skips comments/strings."""
+    state = _load_state()
+    params = {"pattern": pattern, "max_matches": max_matches, "scope": scope}
+    if file:
+        params["file"] = file
+    result = _safe_get(state, "/grep", params)
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def symbols(file: str | None = None, kind: str | None = None, limit: int = 100):
+    """List symbols. Optionally filter by file and/or kind."""
+    state = _load_state()
+    params = {"limit": limit}
+    if file:
+        params["file"] = file
+    if kind:
+        params["kind"] = kind
+    result = _safe_get(state, "/symbols", params)
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def peek_file(file: str, start: int = 0, end: int = 50):
+    """Read a range of lines from a file."""
+    state = _load_state()
+    result = _safe_get(state, "/peek", {"file": file, "start": start, "end": end})
+    print(json.dumps(result, indent=2) if isinstance(result, (dict, list)) else result)
+    return result
+
+
+def structure(detail: int = 0, depth: int = 0):
+    """Get project file tree. detail: 0-3, depth: 0=unlimited."""
+    state = _load_state()
+    params = {}
+    if depth:
+        params["depth"] = depth
+    result = _safe_get(state, "/structure", params)
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def variables_list(function: str, file: str):
+    """List local variables in a function."""
+    state = _load_state()
+    result = _safe_get(state, "/symbols/variables", {"function": function, "file": file})
+    print(json.dumps(result, indent=2))
+    return result
+
+
+def cmd_exec(args: argparse.Namespace) -> None:
+    """Execute Python code with helper functions in scope."""
+    code = args.code
+    if not code:
+        print("ERROR: --code argument is required", file=sys.stderr)
+        sys.exit(1)
+
+    exec_globals = {
+        "__builtins__": __builtins__,
+        "search": search,
+        "impl_": impl_,
+        "callers": callers,
+        "tests": tests,
+        "grep": grep,
+        "symbols": symbols,
+        "peek_file": peek_file,
+        "structure": structure,
+        "variables_list": variables_list,
+        "json": json,
+    }
+
+    try:
+        exec(code, exec_globals)
+    except Exception as e:
+        print(f"ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ── Parser ────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="coderlm_cli",
+        description="CLI wrapper for coderlm-server API",
+    )
+
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    # init
+    p_init = sub.add_parser("init", help="Create a session for the current project")
+    p_init.add_argument("--cwd", help="Project directory (default: $PWD)")
+    p_init.add_argument("--host", default=None, help="Server host (default: 127.0.0.1)")
+    p_init.add_argument("--port", type=int, default=None, help="Server port (default: 3000)")
+    p_init.set_defaults(func=cmd_init)
+
+    # status
+    p_status = sub.add_parser("status", help="Show server and session status")
+    p_status.add_argument("--host", default=None)
+    p_status.add_argument("--port", type=int, default=None)
+    p_status.set_defaults(func=cmd_status)
+
+    # structure
+    p_struct = sub.add_parser("structure", help="Get project file tree")
+    p_struct.add_argument("--depth", type=int, default=None, help="Tree depth (0=unlimited)")
+    p_struct.set_defaults(func=cmd_structure)
+
+    # symbols
+    p_sym = sub.add_parser("symbols", help="List symbols")
+    p_sym.add_argument("--kind", help="Filter: function, method, class, struct, enum, trait, interface, constant, type, module")
+    p_sym.add_argument("--file", help="Filter by file path")
+    p_sym.add_argument("--limit", type=int, default=None)
+    p_sym.set_defaults(func=cmd_symbols)
+
+    # search
+    p_search = sub.add_parser("search", help="Search symbols by name")
+    p_search.add_argument("query", help="Search term")
+    p_search.add_argument("--limit", type=int, default=None)
+    p_search.add_argument("--file", help="Filter results to this file path")
+    p_search.set_defaults(func=cmd_search)
+
+    # impl
+    p_impl = sub.add_parser("impl", help="Get full source of a symbol")
+    p_impl.add_argument("symbol", help="Symbol name")
+    p_impl.add_argument("--file", required=True, help="File containing the symbol")
+    p_impl.set_defaults(func=cmd_impl)
+
+    # callers
+    p_callers = sub.add_parser("callers", help="Find call sites for a symbol")
+    p_callers.add_argument("symbol", help="Symbol name")
+    p_callers.add_argument("--file", required=True, help="File containing the symbol")
+    p_callers.add_argument("--limit", type=int, default=None)
+    p_callers.set_defaults(func=cmd_callers)
+
+    # tests
+    p_tests = sub.add_parser("tests", help="Find tests referencing a symbol")
+    p_tests.add_argument("symbol", help="Symbol name")
+    p_tests.add_argument("--file", required=True, help="File containing the symbol")
+    p_tests.add_argument("--limit", type=int, default=None)
+    p_tests.set_defaults(func=cmd_tests)
+
+    # variables
+    p_vars = sub.add_parser("variables", help="List local variables in a function")
+    p_vars.add_argument("function", help="Function name")
+    p_vars.add_argument("--file", required=True, help="File containing the function")
+    p_vars.set_defaults(func=cmd_variables)
+
+    # peek
+    p_peek = sub.add_parser("peek", help="Read a line range from a file")
+    p_peek.add_argument("file", help="File path")
+    p_peek.add_argument("--start", type=int, default=None, help="Start line (0-indexed)")
+    p_peek.add_argument("--end", type=int, default=None, help="End line (exclusive)")
+    p_peek.set_defaults(func=cmd_peek)
+
+    # grep
+    p_grep = sub.add_parser("grep", help="Regex search across all files")
+    p_grep.add_argument("pattern", help="Regex pattern")
+    p_grep.add_argument("--max-matches", type=int, default=None)
+    p_grep.add_argument("--context-lines", type=int, default=None)
+    p_grep.add_argument("--scope", choices=["all", "code"], default=None,
+                         help="Scope filter: 'all' (default) or 'code' (skip comments/strings)")
+    p_grep.add_argument("--file", help="Restrict grep to this file path")
+    p_grep.set_defaults(func=cmd_grep)
+
+    # chunks
+    p_chunks = sub.add_parser("chunks", help="Compute chunk boundaries for a file")
+    p_chunks.add_argument("file", help="File path")
+    p_chunks.add_argument("--size", type=int, default=None, help="Chunk size in bytes")
+    p_chunks.add_argument("--overlap", type=int, default=None, help="Overlap between chunks")
+    p_chunks.set_defaults(func=cmd_chunks)
+
+    # define-file
+    p_dfile = sub.add_parser("define-file", help="Set a description for a file")
+    p_dfile.add_argument("file", help="File path")
+    p_dfile.add_argument("definition", help="Human-readable description")
+    p_dfile.set_defaults(func=cmd_define_file)
+
+    # redefine-file
+    p_rdfile = sub.add_parser("redefine-file", help="Update a file description")
+    p_rdfile.add_argument("file", help="File path")
+    p_rdfile.add_argument("definition", help="Updated description")
+    p_rdfile.set_defaults(func=cmd_redefine_file)
+
+    # define-symbol
+    p_dsym = sub.add_parser("define-symbol", help="Set a description for a symbol")
+    p_dsym.add_argument("symbol", help="Symbol name")
+    p_dsym.add_argument("--file", required=True, help="File containing the symbol")
+    p_dsym.add_argument("definition", help="Human-readable description")
+    p_dsym.set_defaults(func=cmd_define_symbol)
+
+    # redefine-symbol
+    p_rdsym = sub.add_parser("redefine-symbol", help="Update a symbol description")
+    p_rdsym.add_argument("symbol", help="Symbol name")
+    p_rdsym.add_argument("--file", required=True, help="File containing the symbol")
+    p_rdsym.add_argument("definition", help="Updated description")
+    p_rdsym.set_defaults(func=cmd_redefine_symbol)
+
+    # mark
+    p_mark = sub.add_parser("mark", help="Tag a file with a category")
+    p_mark.add_argument("file", help="File path")
+    p_mark.add_argument("type", choices=["documentation", "ignore", "test", "config", "generated", "custom"],
+                         help="Mark type")
+    p_mark.set_defaults(func=cmd_mark)
+
+    # history
+    p_hist = sub.add_parser("history", help="Session command history")
+    p_hist.add_argument("--limit", type=int, default=None)
+    p_hist.set_defaults(func=cmd_history)
+
+    # save-annotations
+    p_save = sub.add_parser("save-annotations", help="Save annotations to disk (.coderlm/annotations.json)")
+    p_save.set_defaults(func=cmd_save_annotations)
+
+    # load-annotations
+    p_load = sub.add_parser("load-annotations", help="Load annotations from disk")
+    p_load.set_defaults(func=cmd_load_annotations)
+
+    # cleanup
+    p_clean = sub.add_parser("cleanup", help="Delete the current session")
+    p_clean.set_defaults(func=cmd_cleanup)
+
+    # batch
+    p_batch = sub.add_parser("batch", help="Run multiple CLI commands in one invocation")
+    p_batch.add_argument("--commands", required=True,
+                          help="Newline-separated CLI commands to execute sequentially")
+    p_batch.set_defaults(func=cmd_batch)
+
+    # exec
+    p_exec = sub.add_parser("exec", help="Execute Python code with coderlm helper functions")
+    p_exec.add_argument("--code", required=True,
+                         help="Python code with access to: search(), impl_(), callers(), tests(), grep(), symbols(), peek_file(), structure(), variables_list()")
+    p_exec.set_defaults(func=cmd_exec)
+
+    return p
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/rules/coderlm.mdc
+++ b/.cursor/rules/coderlm.mdc
@@ -1,4 +1,10 @@
-# CodeRLM — Structural Codebase Exploration ({{PLATFORM_NAME}})
+---
+description: CodeRLM - tree-sitter-backed codebase exploration via index server
+globs:
+alwaysApply: true
+---
+
+# CodeRLM — Structural Codebase Exploration (Cursor)
 
 You have access to a tree-sitter-backed index server that knows the structure of this codebase: every function, every caller, every symbol, every test reference. Use it instead of guessing with grep.
 
@@ -32,34 +38,34 @@ Do not scan files looking for relevant code. Work the way an engineer traces thr
 All commands go through the wrapper script:
 
 ```bash
-python3 {{CLI_PATH}} <command> [args]
+python3 .cursor/coderlm/coderlm_cli.py <command> [args]
 ```
 
 ### Setup
 
 ```bash
-python3 {{CLI_PATH}} init                    # Create session, index the project (response includes L1 structure for free)
-python3 {{CLI_PATH}} structure --depth 2     # File tree with language breakdown
+python3 .cursor/coderlm/coderlm_cli.py init                    # Create session, index the project (response includes L1 structure for free)
+python3 .cursor/coderlm/coderlm_cli.py structure --depth 2     # File tree with language breakdown
 ```
 
 ### Finding Code
 
 ```bash
-python3 {{CLI_PATH}} search "symbol_name" --limit 20             # Find symbols by name (index lookup)
-python3 {{CLI_PATH}} search "symbol_name" --file path/to/file.py  # Restrict search to one file
-python3 {{CLI_PATH}} symbols --kind function --file path          # List all functions in a file
-python3 {{CLI_PATH}} grep "pattern" --max-matches 20              # Regex search
-python3 {{CLI_PATH}} grep "pattern" --scope code                   # Skip matches in comments/strings
-python3 {{CLI_PATH}} grep "pattern" --file path/to/file.py        # Restrict grep to one file
+python3 .cursor/coderlm/coderlm_cli.py search "symbol_name" --limit 20             # Find symbols by name (index lookup)
+python3 .cursor/coderlm/coderlm_cli.py search "symbol_name" --file path/to/file.py  # Restrict search to one file
+python3 .cursor/coderlm/coderlm_cli.py symbols --kind function --file path          # List all functions in a file
+python3 .cursor/coderlm/coderlm_cli.py grep "pattern" --max-matches 20              # Regex search
+python3 .cursor/coderlm/coderlm_cli.py grep "pattern" --scope code                   # Skip matches in comments/strings
+python3 .cursor/coderlm/coderlm_cli.py grep "pattern" --file path/to/file.py        # Restrict grep to one file
 ```
 
 ### Retrieving Exact Code
 
 ```bash
-python3 {{CLI_PATH}} impl function_name --file path        # Full function body (tree-sitter extracted)
-python3 {{CLI_PATH}} peek path --start N --end M           # Exact line range
-python3 {{CLI_PATH}} variables function_name --file path   # Local variables inside a function
-python3 {{CLI_PATH}} chunks path --size 5000 --overlap 200 # Byte-range chunk boundaries (large files)
+python3 .cursor/coderlm/coderlm_cli.py impl function_name --file path        # Full function body (tree-sitter extracted)
+python3 .cursor/coderlm/coderlm_cli.py peek path --start N --end M           # Exact line range
+python3 .cursor/coderlm/coderlm_cli.py variables function_name --file path   # Local variables inside a function
+python3 .cursor/coderlm/coderlm_cli.py chunks path --size 5000 --overlap 200 # Byte-range chunk boundaries (large files)
 ```
 
 **Prefer `impl` and `peek` over reading entire files.** They return exactly the code you need — a single function from a 1000-line file, a specific line range — without loading irrelevant code into context.
@@ -67,8 +73,8 @@ python3 {{CLI_PATH}} chunks path --size 5000 --overlap 200 # Byte-range chunk bo
 ### Tracing Connections
 
 ```bash
-python3 {{CLI_PATH}} callers function_name --file path     # Every call site: file, line, calling code
-python3 {{CLI_PATH}} tests function_name --file path       # Tests referencing this symbol
+python3 .cursor/coderlm/coderlm_cli.py callers function_name --file path     # Every call site: file, line, calling code
+python3 .cursor/coderlm/coderlm_cli.py tests function_name --file path       # Tests referencing this symbol
 ```
 
 These search the entire indexed codebase, not just files you've already seen.
@@ -79,14 +85,14 @@ For 2+ related lookups, use `batch` (sequential CLI commands) or `exec` (Python 
 
 ```bash
 # Batch — runs each line as a CLI subcommand, in order, sharing the session
-python3 {{CLI_PATH}} batch --commands "
+python3 .cursor/coderlm/coderlm_cli.py batch --commands "
   search MyFunction
   impl MyFunction --file path/to/file.py
   callers MyFunction --file path/to/file.py
 "
 
 # Exec — Python with helpers in scope; later queries can use earlier results
-python3 {{CLI_PATH}} exec --code "
+python3 .cursor/coderlm/coderlm_cli.py exec --code "
   hits = search('serialize_response')
   if hits.get('symbols'):
       sym = hits['symbols'][0]
@@ -103,11 +109,11 @@ python3 {{CLI_PATH}} exec --code "
 ### Annotating
 
 ```bash
-python3 {{CLI_PATH}} define-file src/server/mod.rs "HTTP routing and handler dispatch"
-python3 {{CLI_PATH}} define-symbol handle_request --file src/server/mod.rs "Routes requests by method+path"
-python3 {{CLI_PATH}} mark tests/integration.rs test
-python3 {{CLI_PATH}} save-annotations                      # Persist to disk (.coderlm/annotations.json)
-python3 {{CLI_PATH}} load-annotations                      # Reload from disk (also auto-loaded on init)
+python3 .cursor/coderlm/coderlm_cli.py define-file src/server/mod.rs "HTTP routing and handler dispatch"
+python3 .cursor/coderlm/coderlm_cli.py define-symbol handle_request --file src/server/mod.rs "Routes requests by method+path"
+python3 .cursor/coderlm/coderlm_cli.py mark tests/integration.rs test
+python3 .cursor/coderlm/coderlm_cli.py save-annotations                      # Persist to disk (.coderlm/annotations.json)
+python3 .cursor/coderlm/coderlm_cli.py load-annotations                      # Reload from disk (also auto-loaded on init)
 ```
 
 Annotations persist across queries within a session. Use `save-annotations` to persist across sessions.
@@ -115,7 +121,7 @@ Annotations persist across queries within a session. Use `save-annotations` to p
 ### Cleanup
 
 ```bash
-python3 {{CLI_PATH}} cleanup                               # End session
+python3 .cursor/coderlm/coderlm_cli.py cleanup                               # End session
 ```
 
 ## Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
-# CodeRLM — Structural Codebase Exploration ({{PLATFORM_NAME}})
+<!-- coderlm-start -->
+# CodeRLM — Structural Codebase Exploration (Codex CLI)
 
 You have access to a tree-sitter-backed index server that knows the structure of this codebase: every function, every caller, every symbol, every test reference. Use it instead of guessing with grep.
 
@@ -32,34 +33,34 @@ Do not scan files looking for relevant code. Work the way an engineer traces thr
 All commands go through the wrapper script:
 
 ```bash
-python3 {{CLI_PATH}} <command> [args]
+python3 .codex/coderlm/coderlm_cli.py <command> [args]
 ```
 
 ### Setup
 
 ```bash
-python3 {{CLI_PATH}} init                    # Create session, index the project (response includes L1 structure for free)
-python3 {{CLI_PATH}} structure --depth 2     # File tree with language breakdown
+python3 .codex/coderlm/coderlm_cli.py init                    # Create session, index the project (response includes L1 structure for free)
+python3 .codex/coderlm/coderlm_cli.py structure --depth 2     # File tree with language breakdown
 ```
 
 ### Finding Code
 
 ```bash
-python3 {{CLI_PATH}} search "symbol_name" --limit 20             # Find symbols by name (index lookup)
-python3 {{CLI_PATH}} search "symbol_name" --file path/to/file.py  # Restrict search to one file
-python3 {{CLI_PATH}} symbols --kind function --file path          # List all functions in a file
-python3 {{CLI_PATH}} grep "pattern" --max-matches 20              # Regex search
-python3 {{CLI_PATH}} grep "pattern" --scope code                   # Skip matches in comments/strings
-python3 {{CLI_PATH}} grep "pattern" --file path/to/file.py        # Restrict grep to one file
+python3 .codex/coderlm/coderlm_cli.py search "symbol_name" --limit 20             # Find symbols by name (index lookup)
+python3 .codex/coderlm/coderlm_cli.py search "symbol_name" --file path/to/file.py  # Restrict search to one file
+python3 .codex/coderlm/coderlm_cli.py symbols --kind function --file path          # List all functions in a file
+python3 .codex/coderlm/coderlm_cli.py grep "pattern" --max-matches 20              # Regex search
+python3 .codex/coderlm/coderlm_cli.py grep "pattern" --scope code                   # Skip matches in comments/strings
+python3 .codex/coderlm/coderlm_cli.py grep "pattern" --file path/to/file.py        # Restrict grep to one file
 ```
 
 ### Retrieving Exact Code
 
 ```bash
-python3 {{CLI_PATH}} impl function_name --file path        # Full function body (tree-sitter extracted)
-python3 {{CLI_PATH}} peek path --start N --end M           # Exact line range
-python3 {{CLI_PATH}} variables function_name --file path   # Local variables inside a function
-python3 {{CLI_PATH}} chunks path --size 5000 --overlap 200 # Byte-range chunk boundaries (large files)
+python3 .codex/coderlm/coderlm_cli.py impl function_name --file path        # Full function body (tree-sitter extracted)
+python3 .codex/coderlm/coderlm_cli.py peek path --start N --end M           # Exact line range
+python3 .codex/coderlm/coderlm_cli.py variables function_name --file path   # Local variables inside a function
+python3 .codex/coderlm/coderlm_cli.py chunks path --size 5000 --overlap 200 # Byte-range chunk boundaries (large files)
 ```
 
 **Prefer `impl` and `peek` over reading entire files.** They return exactly the code you need — a single function from a 1000-line file, a specific line range — without loading irrelevant code into context.
@@ -67,8 +68,8 @@ python3 {{CLI_PATH}} chunks path --size 5000 --overlap 200 # Byte-range chunk bo
 ### Tracing Connections
 
 ```bash
-python3 {{CLI_PATH}} callers function_name --file path     # Every call site: file, line, calling code
-python3 {{CLI_PATH}} tests function_name --file path       # Tests referencing this symbol
+python3 .codex/coderlm/coderlm_cli.py callers function_name --file path     # Every call site: file, line, calling code
+python3 .codex/coderlm/coderlm_cli.py tests function_name --file path       # Tests referencing this symbol
 ```
 
 These search the entire indexed codebase, not just files you've already seen.
@@ -79,14 +80,14 @@ For 2+ related lookups, use `batch` (sequential CLI commands) or `exec` (Python 
 
 ```bash
 # Batch — runs each line as a CLI subcommand, in order, sharing the session
-python3 {{CLI_PATH}} batch --commands "
+python3 .codex/coderlm/coderlm_cli.py batch --commands "
   search MyFunction
   impl MyFunction --file path/to/file.py
   callers MyFunction --file path/to/file.py
 "
 
 # Exec — Python with helpers in scope; later queries can use earlier results
-python3 {{CLI_PATH}} exec --code "
+python3 .codex/coderlm/coderlm_cli.py exec --code "
   hits = search('serialize_response')
   if hits.get('symbols'):
       sym = hits['symbols'][0]
@@ -103,11 +104,11 @@ python3 {{CLI_PATH}} exec --code "
 ### Annotating
 
 ```bash
-python3 {{CLI_PATH}} define-file src/server/mod.rs "HTTP routing and handler dispatch"
-python3 {{CLI_PATH}} define-symbol handle_request --file src/server/mod.rs "Routes requests by method+path"
-python3 {{CLI_PATH}} mark tests/integration.rs test
-python3 {{CLI_PATH}} save-annotations                      # Persist to disk (.coderlm/annotations.json)
-python3 {{CLI_PATH}} load-annotations                      # Reload from disk (also auto-loaded on init)
+python3 .codex/coderlm/coderlm_cli.py define-file src/server/mod.rs "HTTP routing and handler dispatch"
+python3 .codex/coderlm/coderlm_cli.py define-symbol handle_request --file src/server/mod.rs "Routes requests by method+path"
+python3 .codex/coderlm/coderlm_cli.py mark tests/integration.rs test
+python3 .codex/coderlm/coderlm_cli.py save-annotations                      # Persist to disk (.coderlm/annotations.json)
+python3 .codex/coderlm/coderlm_cli.py load-annotations                      # Reload from disk (also auto-loaded on init)
 ```
 
 Annotations persist across queries within a session. Use `save-annotations` to persist across sessions.
@@ -115,7 +116,7 @@ Annotations persist across queries within a session. Use `save-annotations` to p
 ### Cleanup
 
 ```bash
-python3 {{CLI_PATH}} cleanup                               # End session
+python3 .codex/coderlm/coderlm_cli.py cleanup                               # End session
 ```
 
 ## Workflow
@@ -172,3 +173,5 @@ Steps 3-7 repeat. A typical exploration is: find a symbol → read its implement
 | Zig        | `.zig`, `.zon`                |
 
 All file types appear in the file tree and are searchable via peek/grep, but only the above produce parsed symbols.
+
+<!-- coderlm-end -->

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Options:
 | Go         | `.go`                         | tree-sitter  |
 | Java       | `.java`                       | tree-sitter  |
 | Scala      | `.scala`, `.sc`               | tree-sitter  |
+| Elixir     | `.ex`, `.exs`                 | tree-sitter  |
 | Ruby       | `.rb`, `.rake`                | tree-sitter  |
 | PHP        | `.php`, `.phtml`              | tree-sitter  |
 | Zig        | `.zig`, `.zon`                | tree-sitter  |

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'When exploring code in supported languages (Rust, Python, TypeScript, JavaScript, Go, Java, Scala, Ruby, PHP, Zig), invoke Skill(coderlm) to use the tree-sitter index. For config files, markdown, small single-file reads, or unsupported languages, use Read/Grep/Glob directly. When using coderlm: CLI=\".claude/coderlm_state/coderlm_cli.py\". For one-off lookups use python3 $CLI search/impl/callers. For multiple lookups use python3 $CLI batch --commands \"...\" or python3 $CLI exec --code \"...\". IMPORTANT: Always include actual code extracts in your answer, not just prose descriptions.'"
+            "command": "echo 'When exploring code in supported languages (Rust, Python, TypeScript, JavaScript, Go, Java, Scala, Elixir, Ruby, PHP, Zig, SQL), invoke Skill(coderlm) to use the tree-sitter index. For config files, markdown, small single-file reads, or unsupported languages, use Read/Grep/Glob directly. When using coderlm: CLI=\".claude/coderlm_state/coderlm_cli.py\". For one-off lookups use python3 $CLI search/impl/callers. For multiple lookups use python3 $CLI batch --commands \"...\" or python3 $CLI exec --code \"...\". IMPORTANT: Always include actual code extracts in your answer, not just prose descriptions.'"
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SubagentStart\",\"additionalContext\":\"For code in supported languages (Rust, Python, TypeScript, JavaScript, Go, Java, Scala, Ruby, PHP, Zig), use the coderlm tree-sitter index. CLI=\\\".claude/coderlm_state/coderlm_cli.py\\\". For one-off: python3 $CLI search/impl/callers. For batching: python3 $CLI batch --commands \\\"...\\\" or python3 $CLI exec --code \\\"...\\\". Always include actual code extracts in answers, not just prose.\"}}'"
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SubagentStart\",\"additionalContext\":\"For code in supported languages (Rust, Python, TypeScript, JavaScript, Go, Java, Scala, Elixir, Ruby, PHP, Zig, SQL), use the coderlm tree-sitter index. CLI=\\\".claude/coderlm_state/coderlm_cli.py\\\". For one-off: python3 $CLI search/impl/callers. For batching: python3 $CLI batch --commands \\\"...\\\" or python3 $CLI exec --code \\\"...\\\". Always include actual code extracts in answers, not just prose.\"}}'"
           }
         ]
       }

--- a/plugin/skills/coderlm/SKILL.md
+++ b/plugin/skills/coderlm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coderlm
-description: "Structural codebase navigation for supported languages (Rust, Python, TypeScript, JavaScript, Go, Java, Scala, Ruby, PHP, Zig, SQL). Provides tree-sitter-backed indexing: find symbols by name, get exact function bodies, follow caller chains, discover tests. Works best combined with the Read tool: use coderlm CLI (`search`, `impl`, `callers`) to locate the right code across a codebase, then `Read` the identified files directly for full context. Use for: tracing execution paths across multiple files, answering 'what calls X', 'how does X work', 'where is X defined'. Avoid raw bash grep/find — use the coderlm `grep` command instead."
+description: "Structural codebase navigation for supported languages (Rust, Python, TypeScript, JavaScript, Go, Java, Scala, Elixir, Ruby, PHP, Zig, SQL). Provides tree-sitter-backed indexing: find symbols by name, get exact function bodies, follow caller chains, discover tests, and trace execution paths. Works best combined with targeted file reads: use coderlm CLI (`search`, `impl`, `callers`, `grep`) to locate the right code across a codebase, then read identified files directly when full context is needed. Use for: answering 'what calls X', 'how does X work', 'where is X defined', and 'where does this error come from'. Avoid raw bash grep/find — use the coderlm `grep` command instead."
 allowed-tools:
   - Bash
   - Read
@@ -116,5 +116,44 @@ Available helpers in exec mode: `search()`, `impl_()`, `callers()`, `tests()`, `
 
 This skill reads `$ARGUMENTS`. Accepted patterns:
 - `query=<question>` (required): what to find or understand
-- `cwd=<path>` (optional): project directory
-- `port=<N>` (optional): server port (default: 3000)
+- `cwd=<path>` (optional): project directory, defaults to cwd
+- `port=<N>` (optional): server port, defaults to 3000
+
+If no query is provided, ask what the user wants to find or understand about the codebase.
+
+## Workflow
+
+1. **Init** — `cli init` to create a session and index the project.
+2. **Orient** — `cli structure` to see the project layout. Identify likely starting points.
+3. **Find the entrypoint** — `cli search` or `cli grep` to locate the starting symbol or pattern.
+4. **Retrieve** — `cli impl` to read the exact implementation. Not the file. The function.
+5. **Trace** — `cli callers` to see what calls it. `cli impl` on those callers. Follow the chain.
+6. **Widen** — `cli tests` to find test coverage. `cli grep` for related patterns discovered during tracing.
+7. **Annotate** — `cli define-symbol` and `cli define-file` as understanding solidifies.
+8. **Synthesize** — Compile findings into a coherent answer with specific file:line references.
+
+Steps 3–7 repeat. A typical exploration is: find a symbol → read its implementation → trace its callers → read those implementations → discover related symbols → repeat until the causal chain is clear.
+
+## When to Use the Server vs Native Tools
+
+| Task | Use server | Why |
+|------|-----------|-----|
+| Find a function by name | `search` | Index lookup, not file globbing |
+| Find code when name is unknown | `grep` + `symbols` | Searches all indexed files at once |
+| Get a function's source | `impl` | Returns just that function, even from large files |
+| Read specific lines | `peek` | Surgical extraction, not the whole file |
+| Find what calls a function | `callers` | Cross-project search with exact call sites |
+| Find tests for a function | `tests` | By symbol reference, not filename guessing |
+| Get project overview | `structure` | Tree with file counts and language breakdown |
+| Read an entire small file | Read tool | When you genuinely need the whole file |
+
+**Default to the server.** Use Read only when you need an entire file or the server is unavailable.
+
+## Troubleshooting
+
+- **"Cannot connect to coderlm-server"** — Server not running. Start with `coderlm-server serve`.
+- **"No active session"** — Run `cli init` first.
+- **"Project was evicted"** — Server hit capacity (default 5 projects). Re-run `cli init`.
+- **Search returns nothing relevant** — Try broader grep patterns or list all symbols: `cli symbols --limit 200`.
+
+For the full API endpoint reference, see [references/api-reference.md](references/api-reference.md).

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tree-sitter",
+ "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
@@ -1253,6 +1254,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,6 +35,7 @@ tree-sitter-scala = "0.24"
 tree-sitter-ruby = "0.23"
 tree-sitter-php = "0.23"
 tree-sitter-zig = "1.1"
+tree-sitter-elixir = "0.3.5"
 
 # Concurrency
 dashmap = "6"

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -4,6 +4,9 @@
 pub const DEFAULT_IGNORE_DIRS: &[&str] = &[
     "node_modules",
     "vendor",
+    "deps",
+    "_build",
+    ".journey",
     "__pycache__",
     ".pycache",
     "target",
@@ -35,10 +38,10 @@ pub const DEFAULT_IGNORE_DIRS: &[&str] = &[
 /// File extensions that are binary or otherwise useless for code reading.
 pub const DEFAULT_IGNORE_EXTENSIONS: &[&str] = &[
     "min.js", "min.css", "pyc", "pyo", "class", "o", "so", "dylib", "dll", "exe", "a", "lib",
-    "jar", "war", "ear", "zip", "tar", "gz", "bz2", "xz", "7z", "rar", "png", "jpg", "jpeg",
-    "gif", "bmp", "ico", "svg", "webp", "mp3", "mp4", "avi", "mov", "wmv", "flv", "woff",
-    "woff2", "ttf", "eot", "otf", "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "db",
-    "sqlite", "sqlite3", "lock", "map",
+    "jar", "war", "ear", "zip", "tar", "gz", "bz2", "xz", "7z", "rar", "png", "jpg", "jpeg", "gif",
+    "bmp", "ico", "svg", "webp", "mp3", "mp4", "avi", "mov", "wmv", "flv", "woff", "woff2", "ttf",
+    "eot", "otf", "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "db", "sqlite", "sqlite3",
+    "lock", "map",
 ];
 
 /// Maximum file size (in bytes) to index by default. Files larger than this

--- a/server/src/index/file_entry.rs
+++ b/server/src/index/file_entry.rs
@@ -12,6 +12,7 @@ pub enum Language {
     Go,
     Java,
     Scala,
+    Elixir,
     C,
     Cpp,
     Ruby,
@@ -38,6 +39,7 @@ impl Language {
             "go" => Language::Go,
             "java" => Language::Java,
             "scala" | "sc" => Language::Scala,
+            "ex" | "exs" => Language::Elixir,
             "c" | "h" => Language::C,
             "cpp" | "cc" | "cxx" | "hpp" | "hxx" | "hh" => Language::Cpp,
             "rb" | "rake" => Language::Ruby,
@@ -66,8 +68,17 @@ impl Language {
     pub fn has_tree_sitter_support(&self) -> bool {
         matches!(
             self,
-            Language::Rust | Language::Python | Language::TypeScript | Language::JavaScript | Language::Go
-            | Language::Java | Language::Scala | Language::Ruby | Language::Php | Language::Zig
+            Language::Rust
+                | Language::Python
+                | Language::TypeScript
+                | Language::JavaScript
+                | Language::Go
+                | Language::Java
+                | Language::Scala
+                | Language::Elixir
+                | Language::Ruby
+                | Language::Php
+                | Language::Zig
         )
     }
 }

--- a/server/src/index/watcher.rs
+++ b/server/src/index/watcher.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
+use notify_debouncer_mini::{DebouncedEventKind, new_debouncer};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -9,8 +9,8 @@ use tracing::{debug, info, warn};
 use crate::config;
 use crate::index::file_entry::FileEntry;
 use crate::index::file_tree::FileTree;
-use crate::symbols::parser::extract_symbols_from_file;
 use crate::symbols::SymbolTable;
+use crate::symbols::parser::extract_symbols_from_file;
 
 /// Start the filesystem watcher. Returns a handle that keeps the watcher alive.
 /// Drop the handle to stop watching.
@@ -82,7 +82,14 @@ fn handle_events(
         match event.kind {
             DebouncedEventKind::Any => {
                 if path.is_file() {
-                    handle_file_change(root, file_tree, symbol_table, max_file_size, &rel_path, path);
+                    handle_file_change(
+                        root,
+                        file_tree,
+                        symbol_table,
+                        max_file_size,
+                        &rel_path,
+                        path,
+                    );
                 } else if !path.exists() {
                     handle_file_delete(file_tree, symbol_table, &rel_path);
                 }
@@ -149,11 +156,7 @@ fn handle_file_change(
     }
 }
 
-fn handle_file_delete(
-    file_tree: &Arc<FileTree>,
-    symbol_table: &Arc<SymbolTable>,
-    rel_path: &str,
-) {
+fn handle_file_delete(file_tree: &Arc<FileTree>, symbol_table: &Arc<SymbolTable>, rel_path: &str) {
     if file_tree.remove(rel_path).is_some() {
         symbol_table.remove_file(rel_path);
         debug!("Removed {} from index", rel_path);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -12,7 +12,10 @@ use tracing::info;
 use server::state::AppState;
 
 #[derive(Parser)]
-#[command(name = "coderlm", about = "CoderLM REPL server for code-aware agent sessions")]
+#[command(
+    name = "coderlm",
+    about = "CoderLM REPL server for code-aware agent sessions"
+)]
 struct Cli {
     /// Subcommand
     #[command(subcommand)]
@@ -86,9 +89,9 @@ async fn run_server(
     // If an initial path was provided, pre-index it
     if let Some(ref p) = path {
         info!("Pre-indexing project: {}", p.display());
-        state.get_or_create_project(p).map_err(|e| {
-            anyhow::anyhow!("Failed to index '{}': {}", p.display(), e)
-        })?;
+        state
+            .get_or_create_project(p)
+            .map_err(|e| anyhow::anyhow!("Failed to index '{}': {}", p.display(), e))?;
     }
 
     // Build router
@@ -100,7 +103,10 @@ async fn run_server(
     if let Some(ref p) = path {
         info!("coderlm serving {} on http://{}", p.display(), addr);
     } else {
-        info!("coderlm server listening on http://{} (no project pre-indexed)", addr);
+        info!(
+            "coderlm server listening on http://{} (no project pre-indexed)",
+            addr
+        );
     }
 
     axum::serve(listener, app).await?;

--- a/server/src/ops/annotations.rs
+++ b/server/src/ops/annotations.rs
@@ -94,8 +94,8 @@ pub fn load_annotations(
 
     let json = std::fs::read_to_string(&annotations_path)
         .map_err(|e| format!("Failed to read annotations: {}", e))?;
-    let data: AnnotationData = serde_json::from_str(&json)
-        .map_err(|e| format!("Failed to parse annotations: {}", e))?;
+    let data: AnnotationData =
+        serde_json::from_str(&json).map_err(|e| format!("Failed to parse annotations: {}", e))?;
 
     // Apply file definitions
     for (path, def) in &data.file_definitions {

--- a/server/src/ops/content.rs
+++ b/server/src/ops/content.rs
@@ -29,8 +29,8 @@ pub fn peek(
     }
 
     let abs_path = root.join(file);
-    let source =
-        std::fs::read_to_string(&abs_path).map_err(|e| format!("Failed to read '{}': {}", file, e))?;
+    let source = std::fs::read_to_string(&abs_path)
+        .map_err(|e| format!("Failed to read '{}': {}", file, e))?;
 
     let lines: Vec<&str> = source.lines().collect();
     let total_lines = lines.len();
@@ -98,7 +98,15 @@ pub fn grep(
     max_matches: usize,
     context_lines: usize,
 ) -> Result<GrepResponse, String> {
-    grep_with_scope(root, file_tree, pattern, max_matches, context_lines, GrepScope::All, None)
+    grep_with_scope(
+        root,
+        file_tree,
+        pattern,
+        max_matches,
+        context_lines,
+        GrepScope::All,
+        None,
+    )
 }
 
 pub fn grep_with_scope(
@@ -178,10 +186,8 @@ pub fn grep_with_scope(
                     let ctx_start = i.saturating_sub(context_lines);
                     let ctx_end = (i + context_lines + 1).min(lines.len());
 
-                    let context_before: Vec<String> = lines[ctx_start..i]
-                        .iter()
-                        .map(|l| l.to_string())
-                        .collect();
+                    let context_before: Vec<String> =
+                        lines[ctx_start..i].iter().map(|l| l.to_string()).collect();
                     let context_after: Vec<String> = lines[(i + 1)..ctx_end]
                         .iter()
                         .map(|l| l.to_string())
@@ -228,55 +234,83 @@ fn compute_non_code_ranges(source: &str, language: Language) -> Vec<(usize, usiz
 
     // Query for comment and string nodes
     let query_str = match language {
-        Language::Rust => r#"
+        Language::Rust => {
+            r#"
             (line_comment) @skip
             (block_comment) @skip
             (string_literal) @skip
             (raw_string_literal) @skip
-        "#,
-        Language::Python => r#"
+        "#
+        }
+        Language::Python => {
+            r#"
             (comment) @skip
             (string) @skip
-        "#,
-        Language::TypeScript | Language::JavaScript => r#"
+        "#
+        }
+        Language::TypeScript | Language::JavaScript => {
+            r#"
             (comment) @skip
             (string) @skip
             (template_string) @skip
-        "#,
-        Language::Go => r#"
+        "#
+        }
+        Language::Go => {
+            r#"
             (comment) @skip
             (raw_string_literal) @skip
             (interpreted_string_literal) @skip
-        "#,
-        Language::Java => r#"
+        "#
+        }
+        Language::Java => {
+            r#"
             (line_comment) @skip
             (block_comment) @skip
             (string_literal) @skip
-        "#,
-        Language::Scala => r#"
+        "#
+        }
+        Language::Scala => {
+            r#"
             (comment) @skip
             (block_comment) @skip
             (string) @skip
             (interpolated_string_expression) @skip
-        "#,
-        Language::Ruby => r#"
+        "#
+        }
+        Language::Ruby => {
+            r#"
             (comment) @skip
             (string) @skip
             (heredoc_body) @skip
             (regex) @skip
-        "#,
-        Language::Php => r#"
+        "#
+        }
+        Language::Php => {
+            r#"
             (comment) @skip
             (string) @skip
             (encapsed_string) @skip
             (heredoc) @skip
             (nowdoc) @skip
-        "#,
-        Language::Zig => r#"
+        "#
+        }
+        Language::Zig => {
+            r#"
             (comment) @skip
             (string) @skip
             (multiline_string) @skip
-        "#,
+        "#
+        }
+        Language::Elixir => {
+            r#"
+            (comment) @skip
+            (string) @skip
+            (charlist) @skip
+            (sigil) @skip
+            (quoted_atom) @skip
+            (quoted_keyword) @skip
+        "#
+        }
         _ => return Vec::new(),
     };
 
@@ -349,8 +383,8 @@ pub fn chunk_indices(
     }
 
     let abs_path = root.join(file);
-    let source =
-        std::fs::read_to_string(&abs_path).map_err(|e| format!("Failed to read '{}': {}", file, e))?;
+    let source = std::fs::read_to_string(&abs_path)
+        .map_err(|e| format!("Failed to read '{}': {}", file, e))?;
 
     let total_bytes = source.len();
     let step = size - overlap;

--- a/server/src/ops/history.rs
+++ b/server/src/ops/history.rs
@@ -2,7 +2,11 @@ use crate::server::session::HistoryEntry;
 use crate::server::state::AppState;
 use serde::Serialize;
 
-pub fn get_history(state: &AppState, session_id: &str, limit: usize) -> Result<Vec<HistoryEntry>, String> {
+pub fn get_history(
+    state: &AppState,
+    session_id: &str,
+    limit: usize,
+) -> Result<Vec<HistoryEntry>, String> {
     let session = state
         .inner
         .sessions

--- a/server/src/ops/structure.rs
+++ b/server/src/ops/structure.rs
@@ -5,8 +5,8 @@ use serde::Serialize;
 
 use crate::index::file_entry::FileMark;
 use crate::index::file_tree::FileTree;
-use crate::symbols::symbol::SymbolKind;
 use crate::symbols::SymbolTable;
+use crate::symbols::symbol::SymbolKind;
 
 #[derive(Debug, Serialize)]
 pub struct StructureResponse {
@@ -113,13 +113,11 @@ pub fn get_structure_with_detail(
 
         let source = if detail >= 3 {
             let abs_path = root.join(&sym.file);
-            std::fs::read_to_string(&abs_path)
-                .ok()
-                .and_then(|src| {
-                    let start = sym.byte_range.0;
-                    let end = sym.byte_range.1.min(src.len());
-                    Some(src[start..end].to_string())
-                })
+            std::fs::read_to_string(&abs_path).ok().and_then(|src| {
+                let start = sym.byte_range.0;
+                let end = sym.byte_range.1.min(src.len());
+                Some(src[start..end].to_string())
+            })
         } else {
             None
         };
@@ -128,16 +126,17 @@ pub fn get_structure_with_detail(
             name: sym.name.clone(),
             kind: sym.kind,
             signature: sym.signature.clone(),
-            parent: if detail >= 2 { sym.parent.clone() } else { None },
+            parent: if detail >= 2 {
+                sym.parent.clone()
+            } else {
+                None
+            },
             definition: sym.definition.clone(),
             line: sym.line_range.0,
             source,
         };
 
-        file_map
-            .entry(sym.file.clone())
-            .or_default()
-            .push(summary);
+        file_map.entry(sym.file.clone()).or_default().push(summary);
     }
 
     // Sort symbols within each file by line number
@@ -159,11 +158,7 @@ pub fn get_structure_with_detail(
     }
 }
 
-pub fn define_file(
-    file_tree: &Arc<FileTree>,
-    file: &str,
-    definition: &str,
-) -> Result<(), String> {
+pub fn define_file(file_tree: &Arc<FileTree>, file: &str, definition: &str) -> Result<(), String> {
     if let Some(mut entry) = file_tree.files.get_mut(file) {
         if entry.definition.is_some() {
             return Err(format!(
@@ -191,11 +186,7 @@ pub fn redefine_file(
     }
 }
 
-pub fn mark_file(
-    file_tree: &Arc<FileTree>,
-    file: &str,
-    mark_str: &str,
-) -> Result<(), String> {
+pub fn mark_file(file_tree: &Arc<FileTree>, file: &str, mark_str: &str) -> Result<(), String> {
     let mark = FileMark::from_str(mark_str)
         .ok_or_else(|| format!("Unknown mark type: '{}'. Valid: documentation, ignore, test, config, generated, custom", mark_str))?;
 

--- a/server/src/ops/symbol_ops.rs
+++ b/server/src/ops/symbol_ops.rs
@@ -5,9 +5,9 @@ use tree_sitter::StreamingIterator;
 
 use crate::index::file_entry::Language;
 use crate::index::file_tree::FileTree;
+use crate::symbols::SymbolTable;
 use crate::symbols::queries;
 use crate::symbols::symbol::{Symbol, SymbolKind};
-use crate::symbols::SymbolTable;
 
 pub fn list_symbols(
     symbol_table: &Arc<SymbolTable>,
@@ -25,7 +25,11 @@ pub fn list_symbols(
         results.retain(|s| s.kind == kind);
     }
 
-    results.sort_by(|a, b| a.file.cmp(&b.file).then(a.line_range.0.cmp(&b.line_range.0)));
+    results.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then(a.line_range.0.cmp(&b.line_range.0))
+    });
     results.truncate(limit);
     results
 }
@@ -36,7 +40,14 @@ pub fn search_symbols(
     limit: usize,
     file_filter: Option<&str>,
 ) -> Vec<Symbol> {
-    let mut results = symbol_table.search(query, if file_filter.is_some() { limit * 5 } else { limit });
+    let mut results = symbol_table.search(
+        query,
+        if file_filter.is_some() {
+            limit * 5
+        } else {
+            limit
+        },
+    );
 
     // Apply file filter if provided
     if let Some(file) = file_filter {
@@ -46,8 +57,10 @@ pub fn search_symbols(
     // If few results, also search by signature substring
     if results.len() < limit {
         let query_lower = query.to_lowercase();
-        let existing_keys: std::collections::HashSet<String> =
-            results.iter().map(|s| format!("{}::{}", s.file, s.name)).collect();
+        let existing_keys: std::collections::HashSet<String> = results
+            .iter()
+            .map(|s| format!("{}::{}", s.file, s.name))
+            .collect();
 
         for entry in symbol_table.symbols.iter() {
             let sym = entry.value();
@@ -168,6 +181,10 @@ pub fn find_callers(
             Err(_) => continue,
         };
 
+        if !source.contains(symbol_name) {
+            continue;
+        }
+
         let file_callers = if language.has_tree_sitter_support() {
             find_callers_ast(&source, &rel_path, language, symbol_name, file)
         } else {
@@ -214,7 +231,11 @@ fn find_callers_ast(
         Err(_) => return find_callers_regex(source, rel_path, symbol_name, definition_file),
     };
 
-    let capture_names: Vec<String> = query.capture_names().iter().map(|s| s.to_string()).collect();
+    let capture_names: Vec<String> = query
+        .capture_names()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let callee_idx = capture_names.iter().position(|n| n == "callee");
 
     let mut cursor = tree_sitter::QueryCursor::new();
@@ -229,10 +250,7 @@ fn find_callers_ast(
                     let line_num = cap.node.start_position().row + 1;
                     // Skip the definition itself
                     if rel_path == definition_file {
-                        let line_text = source
-                            .lines()
-                            .nth(line_num - 1)
-                            .unwrap_or("");
+                        let line_text = source.lines().nth(line_num - 1).unwrap_or("");
                         if is_definition_line(line_text, symbol_name, language) {
                             continue;
                         }
@@ -275,6 +293,14 @@ fn find_callers_regex(
             if rel_path == definition_file
                 && (line.contains(&format!("fn {}", symbol_name))
                     || line.contains(&format!("def {}", symbol_name))
+                    || line.contains(&format!("defp {}", symbol_name))
+                    || line.contains(&format!("defmacro {}", symbol_name))
+                    || line.contains(&format!("defmacrop {}", symbol_name))
+                    || line.contains(&format!("defguard {}", symbol_name))
+                    || line.contains(&format!("defguardp {}", symbol_name))
+                    || line.contains(&format!("defmodule {}", symbol_name))
+                    || line.contains(&format!("defprotocol {}", symbol_name))
+                    || line.contains(&format!("defimpl {}", symbol_name))
                     || line.contains(&format!("function {}", symbol_name))
                     || line.contains(&format!("func {}", symbol_name))
                     || line.contains(&format!("class {}", symbol_name))
@@ -301,19 +327,24 @@ fn is_definition_line(line: &str, name: &str, language: Language) -> bool {
         Language::Rust => line.contains(&format!("fn {}", name)),
         Language::Python => line.contains(&format!("def {}", name)),
         Language::TypeScript | Language::JavaScript => {
-            line.contains(&format!("function {}", name))
-                || line.contains(&format!("{} =", name))
+            line.contains(&format!("function {}", name)) || line.contains(&format!("{} =", name))
         }
         Language::Go => line.contains(&format!("func {}", name)),
         Language::Java => {
             line.contains(&format!("class {}", name))
                 || line.contains(&format!("interface {}", name))
                 || line.contains(&format!("enum {}", name))
-                || (line.contains(name) && (line.contains("void ") || line.contains("int ")
-                    || line.contains("String ") || line.contains("boolean ")
-                    || line.contains("long ") || line.contains("double ")
-                    || line.contains("float ") || line.contains("public ")
-                    || line.contains("private ") || line.contains("protected ")))
+                || (line.contains(name)
+                    && (line.contains("void ")
+                        || line.contains("int ")
+                        || line.contains("String ")
+                        || line.contains("boolean ")
+                        || line.contains("long ")
+                        || line.contains("double ")
+                        || line.contains("float ")
+                        || line.contains("public ")
+                        || line.contains("private ")
+                        || line.contains("protected ")))
         }
         Language::Scala => {
             line.contains(&format!("def {}", name))
@@ -321,15 +352,29 @@ fn is_definition_line(line: &str, name: &str, language: Language) -> bool {
                 || line.contains(&format!("class {}", name))
                 || line.contains(&format!("trait {}", name))
         }
+        Language::Elixir => {
+            line.contains(&format!("def {}", name))
+                || line.contains(&format!("defp {}", name))
+                || line.contains(&format!("defmacro {}", name))
+                || line.contains(&format!("defmacrop {}", name))
+                || line.contains(&format!("defguard {}", name))
+                || line.contains(&format!("defguardp {}", name))
+                || line.contains(&format!("defmodule {}", name))
+                || line.contains(&format!("defprotocol {}", name))
+                || line.contains(&format!("defimpl {}", name))
+        }
         Language::Ruby => {
             line.contains(&format!("def {}", name))
                 || line.contains(&format!("def self.{}", name))
                 || line.contains(&format!("class {}", name))
                 || line.contains(&format!("module {}", name))
                 || line.contains(&format!("alias {}", name))
-                || (line.contains(name) && (line.contains("attr_reader")
-                    || line.contains("attr_writer") || line.contains("attr_accessor")
-                    || line.contains("define_method") || line.contains("alias_method")))
+                || (line.contains(name)
+                    && (line.contains("attr_reader")
+                        || line.contains("attr_writer")
+                        || line.contains("attr_accessor")
+                        || line.contains("define_method")
+                        || line.contains("alias_method")))
         }
         Language::Php => {
             line.contains(&format!("function {}", name))
@@ -365,15 +410,19 @@ pub struct CallerInfo {
 /// Find test functions that reference a given symbol.
 pub fn find_tests(
     root: &Path,
-    _file_tree: &Arc<FileTree>,
+    file_tree: &Arc<FileTree>,
     symbol_table: &Arc<SymbolTable>,
     symbol_name: &str,
     file: &str,
     limit: usize,
 ) -> Result<Vec<TestInfo>, String> {
-    let _sym = symbol_table
+    let sym = symbol_table
         .get(file, symbol_name)
         .ok_or_else(|| format!("Symbol '{}' not found in '{}'", symbol_name, file))?;
+
+    if sym.language == Language::Elixir {
+        return Ok(find_exunit_tests(root, file_tree, symbol_name, limit));
+    }
 
     let mut tests = Vec::new();
 
@@ -417,9 +466,7 @@ fn is_test_symbol(sym: &Symbol) -> bool {
         return true;
     }
     match sym.language {
-        Language::Rust => {
-            sym.name.starts_with("test") || sym.file.contains("/tests/")
-        }
+        Language::Rust => sym.name.starts_with("test") || sym.file.contains("/tests/"),
         Language::Python => {
             sym.name.starts_with("test_")
                 || sym.file.contains("test_")
@@ -430,14 +477,15 @@ fn is_test_symbol(sym: &Symbol) -> bool {
                 || sym.file.contains(".spec.")
                 || sym.file.contains("__tests__")
         }
-        Language::Go => {
-            sym.name.starts_with("Test") || sym.file.ends_with("_test.go")
-        }
-        Language::Java => {
-            sym.file.contains("Test") || sym.file.contains("/test/")
-        }
+        Language::Go => sym.name.starts_with("Test") || sym.file.ends_with("_test.go"),
+        Language::Java => sym.file.contains("Test") || sym.file.contains("/test/"),
         Language::Scala => {
             sym.file.contains("Spec") || sym.file.contains("Test") || sym.file.contains("/test/")
+        }
+        Language::Elixir => {
+            sym.file.ends_with("_test.exs")
+                || sym.file.contains("/test/")
+                || sym.file.contains("/test/support/")
         }
         Language::Ruby => {
             sym.name.starts_with("test_")
@@ -523,7 +571,11 @@ fn list_variables_ast(
         Err(_) => return list_variables_regex(&source[fn_start..fn_end], language, function_name),
     };
 
-    let capture_names: Vec<String> = query.capture_names().iter().map(|s| s.to_string()).collect();
+    let capture_names: Vec<String> = query
+        .capture_names()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let var_name_idx = capture_names.iter().position(|n| n == "var.name");
 
     let mut cursor = tree_sitter::QueryCursor::new();
@@ -537,7 +589,11 @@ fn list_variables_ast(
         for cap in m.captures {
             if Some(cap.index as usize) == var_name_idx {
                 let text = cap.node.utf8_text(source.as_bytes()).unwrap_or("");
-                if !text.is_empty() && text != "self" && text != "_" && seen.insert(text.to_string()) {
+                if !text.is_empty()
+                    && text != "self"
+                    && text != "_"
+                    && seen.insert(text.to_string())
+                {
                     variables.push(VariableInfo {
                         name: text.to_string(),
                         function: function_name.to_string(),
@@ -551,11 +607,7 @@ fn list_variables_ast(
 }
 
 /// Regex fallback for variable extraction.
-fn list_variables_regex(
-    body: &str,
-    language: Language,
-    function_name: &str,
-) -> Vec<VariableInfo> {
+fn list_variables_regex(body: &str, language: Language, function_name: &str) -> Vec<VariableInfo> {
     let mut variables = Vec::new();
 
     match language {
@@ -623,6 +675,39 @@ fn list_variables_regex(
                 });
             }
         }
+        Language::Elixir => {
+            let param_re =
+                regex::Regex::new(r"\bdef(?:p|macro|macrop|guard|guardp)?\s+\w+\s*\(([^)]*)\)")
+                    .unwrap();
+            let assign_re = regex::Regex::new(r"\b([a-z_][a-zA-Z0-9_]*)\s*=").unwrap();
+            let bind_re = regex::Regex::new(r"\b([a-z_][a-zA-Z0-9_]*)\s*<-").unwrap();
+            let identifier_re = regex::Regex::new(r"\b([a-z_][a-zA-Z0-9_]*)\b").unwrap();
+
+            for cap in param_re.captures_iter(body) {
+                for segment in cap[1].split(',') {
+                    if let Some(id) = identifier_re.captures(segment) {
+                        variables.push(VariableInfo {
+                            name: id[1].to_string(),
+                            function: function_name.to_string(),
+                        });
+                    }
+                }
+            }
+
+            for cap in assign_re.captures_iter(body) {
+                variables.push(VariableInfo {
+                    name: cap[1].to_string(),
+                    function: function_name.to_string(),
+                });
+            }
+
+            for cap in bind_re.captures_iter(body) {
+                variables.push(VariableInfo {
+                    name: cap[1].to_string(),
+                    function: function_name.to_string(),
+                });
+            }
+        }
         Language::Ruby => {
             let assign_re = regex::Regex::new(r"^\s+(\w+)\s*=").unwrap();
             for cap in assign_re.captures_iter(body) {
@@ -680,6 +765,133 @@ fn list_variables_regex(
     variables.dedup_by(|a, b| a.name == b.name);
 
     variables
+}
+
+fn find_exunit_tests(
+    root: &Path,
+    file_tree: &Arc<FileTree>,
+    symbol_name: &str,
+    limit: usize,
+) -> Vec<TestInfo> {
+    let mut tests = Vec::new();
+
+    for entry in file_tree.files.iter() {
+        let rel_path = entry.key();
+        let file = entry.value();
+        if file.language != Language::Elixir || !is_elixir_test_file(rel_path) {
+            continue;
+        }
+
+        let abs_path = root.join(rel_path);
+        let source = match std::fs::read_to_string(&abs_path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        let language = tree_sitter_elixir::LANGUAGE.into();
+        let mut parser = tree_sitter::Parser::new();
+        if parser.set_language(&language).is_err() {
+            continue;
+        }
+
+        let tree = match parser.parse(&source, None) {
+            Some(t) => t,
+            None => continue,
+        };
+
+        let query = match tree_sitter::Query::new(
+            &language,
+            r#"
+(call
+  target: (identifier) @test.kind
+  (arguments
+    [
+      (string) @test.name
+      (charlist) @test.name
+      (sigil) @test.name
+    ])
+  (#any-of? @test.kind "test" "describe")) @test.def
+"#,
+        ) {
+            Ok(q) => q,
+            Err(_) => continue,
+        };
+
+        let capture_names: Vec<String> = query
+            .capture_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let kind_idx = capture_names.iter().position(|n| n == "test.kind");
+        let name_idx = capture_names.iter().position(|n| n == "test.name");
+        let def_idx = capture_names.iter().position(|n| n == "test.def");
+
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
+
+        while let Some(m) = matches.next() {
+            let mut kind = None;
+            let mut name = None;
+            let mut def_node = None;
+
+            for cap in m.captures {
+                let idx = cap.index as usize;
+                if Some(idx) == kind_idx {
+                    kind = cap
+                        .node
+                        .utf8_text(source.as_bytes())
+                        .ok()
+                        .map(str::to_string);
+                } else if Some(idx) == name_idx {
+                    name = cap
+                        .node
+                        .utf8_text(source.as_bytes())
+                        .ok()
+                        .map(str::to_string);
+                } else if Some(idx) == def_idx {
+                    def_node = Some(cap.node);
+                }
+            }
+
+            let Some(def_node) = def_node else {
+                continue;
+            };
+
+            let start = def_node.start_byte();
+            let end = def_node.end_byte().min(source.len());
+            let body = &source[start..end];
+            if !body.contains(symbol_name) {
+                continue;
+            }
+
+            let kind = kind.unwrap_or_else(|| "test".to_string());
+            let label = clean_elixir_test_name(name.as_deref().unwrap_or(&kind));
+            tests.push(TestInfo {
+                name: format!("{} {}", kind, label),
+                file: rel_path.clone(),
+                line: def_node.start_position().row + 1,
+                signature: source
+                    .lines()
+                    .nth(def_node.start_position().row)
+                    .map(|line| line.trim().to_string())
+                    .unwrap_or_else(|| format!("{} {}", kind, label)),
+            });
+
+            if tests.len() >= limit {
+                return tests;
+            }
+        }
+    }
+
+    tests
+}
+
+fn is_elixir_test_file(path: &str) -> bool {
+    path.ends_with("_test.exs") || path.contains("/test/")
+}
+
+fn clean_elixir_test_name(name: &str) -> String {
+    name.trim().trim_matches('"').trim_matches('\'').to_string()
 }
 
 #[derive(Debug, serde::Serialize)]

--- a/server/src/server/errors.rs
+++ b/server/src/server/errors.rs
@@ -1,6 +1,6 @@
+use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use serde_json::json;
 use thiserror::Error;
 

--- a/server/src/server/routes.rs
+++ b/server/src/server/routes.rs
@@ -6,9 +6,11 @@ use axum::http::HeaderMap;
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
-use crate::ops::{annotations, buffers, content, history, structure, subcalls, symbol_ops, variables};
+use crate::ops::{
+    annotations, buffers, content, history, structure, subcalls, symbol_ops, variables,
+};
 use crate::server::errors::AppError;
 use crate::server::session::Session;
 use crate::server::state::{AppState, Project};
@@ -41,7 +43,13 @@ fn require_project(state: &AppState, headers: &HeaderMap) -> Result<Arc<Project>
     Ok(project)
 }
 
-fn record_history(state: &AppState, session_id: Option<&str>, method: &str, path: &str, preview: &str) {
+fn record_history(
+    state: &AppState,
+    session_id: Option<&str>,
+    method: &str,
+    path: &str,
+    preview: &str,
+) {
     if let Some(id) = session_id {
         if let Some(mut session) = state.inner.sessions.get_mut(id) {
             session.record(method, path, preview);
@@ -90,13 +98,21 @@ pub fn build_routes(state: AppState) -> Router {
         .route("/api/v1/buffers", get(list_buffers).post(create_buffer))
         .route("/api/v1/buffers/from-file", post(buffer_from_file))
         .route("/api/v1/buffers/from-symbol", post(buffer_from_symbol))
-        .route("/api/v1/buffers/{name}", get(get_buffer).delete(delete_buffer))
+        .route(
+            "/api/v1/buffers/{name}",
+            get(get_buffer).delete(delete_buffer),
+        )
         .route("/api/v1/buffers/{name}/peek", get(peek_buffer))
         // Variables
         .route("/api/v1/vars", get(list_vars).post(set_var))
         .route("/api/v1/vars/{name}", get(get_var).delete(delete_var))
         // Subcall results
-        .route("/api/v1/subcall_results", get(get_subcall_results).post(store_subcall_result).delete(clear_subcall_results))
+        .route(
+            "/api/v1/subcall_results",
+            get(get_subcall_results)
+                .post(store_subcall_result)
+                .delete(clear_subcall_results),
+        )
         .with_state(state)
 }
 
@@ -288,12 +304,24 @@ async fn get_structure(
             detail,
         );
         let preview = format!("{} files (L{})", result.file_count, detail);
-        record_history(&state, session_id(&headers).as_deref(), "GET", "/structure", &preview);
+        record_history(
+            &state,
+            session_id(&headers).as_deref(),
+            "GET",
+            "/structure",
+            &preview,
+        );
         Ok(Json(serde_json::to_value(result).unwrap()))
     } else {
         let result = structure::get_structure(&project.file_tree, depth);
         let preview = format!("{} files", result.file_count);
-        record_history(&state, session_id(&headers).as_deref(), "GET", "/structure", &preview);
+        record_history(
+            &state,
+            session_id(&headers).as_deref(),
+            "GET",
+            "/structure",
+            &preview,
+        );
         Ok(Json(serde_json::to_value(result).unwrap()))
     }
 }
@@ -312,7 +340,13 @@ async fn define_file(
     let project = require_project(&state, &headers)?;
     structure::define_file(&project.file_tree, &body.file, &body.definition)
         .map_err(AppError::BadRequest)?;
-    record_history(&state, session_id(&headers).as_deref(), "POST", "/structure/define", &body.file);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "POST",
+        "/structure/define",
+        &body.file,
+    );
     Ok(Json(json!({ "ok": true })))
 }
 
@@ -324,7 +358,13 @@ async fn redefine_file(
     let project = require_project(&state, &headers)?;
     structure::redefine_file(&project.file_tree, &body.file, &body.definition)
         .map_err(AppError::BadRequest)?;
-    record_history(&state, session_id(&headers).as_deref(), "POST", "/structure/redefine", &body.file);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "POST",
+        "/structure/redefine",
+        &body.file,
+    );
     Ok(Json(json!({ "ok": true })))
 }
 
@@ -342,7 +382,13 @@ async fn mark_file(
     let project = require_project(&state, &headers)?;
     structure::mark_file(&project.file_tree, &body.file, &body.mark)
         .map_err(AppError::BadRequest)?;
-    record_history(&state, session_id(&headers).as_deref(), "POST", "/structure/mark", &body.file);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "POST",
+        "/structure/mark",
+        &body.file,
+    );
     Ok(Json(json!({ "ok": true })))
 }
 
@@ -372,7 +418,13 @@ async fn list_symbols(
         limit,
     );
     let preview = format!("{} symbols", results.len());
-    record_history(&state, session_id(&headers).as_deref(), "GET", "/symbols", &preview);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "GET",
+        "/symbols",
+        &preview,
+    );
     Ok(Json(json!({ "symbols": results, "count": results.len() })))
 }
 
@@ -390,9 +442,20 @@ async fn search_symbols(
 ) -> Result<Json<Value>, AppError> {
     let project = require_project(&state, &headers)?;
     let limit = params.limit.unwrap_or(20);
-    let results = symbol_ops::search_symbols(&project.symbol_table, &params.q, limit, params.file.as_deref());
+    let results = symbol_ops::search_symbols(
+        &project.symbol_table,
+        &params.q,
+        limit,
+        params.file.as_deref(),
+    );
     let preview = format!("{} matches for '{}'", results.len(), params.q);
-    record_history(&state, session_id(&headers).as_deref(), "GET", "/symbols/search", &preview);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "GET",
+        "/symbols/search",
+        &preview,
+    );
     Ok(Json(json!({ "symbols": results, "count": results.len() })))
 }
 
@@ -416,7 +479,13 @@ async fn define_symbol(
         &body.definition,
     )
     .map_err(AppError::BadRequest)?;
-    record_history(&state, session_id(&headers).as_deref(), "POST", "/symbols/define", &body.symbol);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "POST",
+        "/symbols/define",
+        &body.symbol,
+    );
     Ok(Json(json!({ "ok": true })))
 }
 
@@ -433,7 +502,13 @@ async fn redefine_symbol(
         &body.definition,
     )
     .map_err(AppError::BadRequest)?;
-    record_history(&state, session_id(&headers).as_deref(), "POST", "/symbols/redefine", &body.symbol);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "POST",
+        "/symbols/redefine",
+        &body.symbol,
+    );
     Ok(Json(json!({ "ok": true })))
 }
 
@@ -456,8 +531,19 @@ async fn get_implementation(
         &params.file,
     )
     .map_err(AppError::NotFound)?;
-    let preview = format!("{}::{} ({} bytes)", params.file, params.symbol, source.len());
-    record_history(&state, session_id(&headers).as_deref(), "GET", "/symbols/implementation", &preview);
+    let preview = format!(
+        "{}::{} ({} bytes)",
+        params.file,
+        params.symbol,
+        source.len()
+    );
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "GET",
+        "/symbols/implementation",
+        &preview,
+    );
     Ok(Json(json!({
         "symbol": params.symbol,
         "file": params.file,
@@ -489,7 +575,13 @@ async fn find_tests(
     )
     .map_err(AppError::NotFound)?;
     let preview = format!("{} tests for {}", tests.len(), params.symbol);
-    record_history(&state, session_id(&headers).as_deref(), "GET", "/symbols/tests", &preview);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "GET",
+        "/symbols/tests",
+        &preview,
+    );
     Ok(Json(json!({ "tests": tests, "count": tests.len() })))
 }
 
@@ -517,7 +609,13 @@ async fn find_callers(
     )
     .map_err(AppError::NotFound)?;
     let preview = format!("{} callers of {}", callers.len(), params.symbol);
-    record_history(&state, session_id(&headers).as_deref(), "GET", "/symbols/callers", &preview);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "GET",
+        "/symbols/callers",
+        &preview,
+    );
     Ok(Json(json!({ "callers": callers, "count": callers.len() })))
 }
 
@@ -541,7 +639,13 @@ async fn list_variables(
     )
     .map_err(AppError::NotFound)?;
     let preview = format!("{} variables in {}", vars.len(), params.function);
-    record_history(&state, session_id(&headers).as_deref(), "GET", "/symbols/variables", &preview);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "GET",
+        "/symbols/variables",
+        &preview,
+    );
     Ok(Json(json!({ "variables": vars, "count": vars.len() })))
 }
 
@@ -564,16 +668,16 @@ async fn peek(
     let project = require_project(&state, &headers)?;
     let start = params.start.unwrap_or(0);
     let end = params.end.unwrap_or(100);
-    let result = content::peek(
-        &project.root,
-        &project.file_tree,
-        &params.file,
-        start,
-        end,
-    )
-    .map_err(AppError::NotFound)?;
+    let result = content::peek(&project.root, &project.file_tree, &params.file, start, end)
+        .map_err(AppError::NotFound)?;
     let preview = format!("{}:{}-{}", params.file, start, end);
-    record_history(&state, session_id(&headers).as_deref(), "GET", "/peek", &preview);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "GET",
+        "/peek",
+        &preview,
+    );
     Ok(Json(serde_json::to_value(result).unwrap()))
 }
 
@@ -610,14 +714,28 @@ async fn grep_handler(
     let file_filter = params.file.clone();
 
     let result = tokio::task::spawn_blocking(move || {
-        content::grep_with_scope(&root, &file_tree, &pattern, max_matches, context_lines, scope, file_filter.as_deref())
+        content::grep_with_scope(
+            &root,
+            &file_tree,
+            &pattern,
+            max_matches,
+            context_lines,
+            scope,
+            file_filter.as_deref(),
+        )
     })
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?
     .map_err(AppError::BadRequest)?;
 
     let preview = format!("{} matches for '{}'", result.total_matches, params.pattern);
-    record_history(&state, session_id(&headers).as_deref(), "GET", "/grep", &preview);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "GET",
+        "/grep",
+        &preview,
+    );
     Ok(Json(serde_json::to_value(result).unwrap()))
 }
 
@@ -645,7 +763,13 @@ async fn chunk_indices(
     )
     .map_err(AppError::BadRequest)?;
     let preview = format!("{} chunks for {}", result.chunks.len(), params.file);
-    record_history(&state, session_id(&headers).as_deref(), "GET", "/chunk_indices", &preview);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "GET",
+        "/chunk_indices",
+        &preview,
+    );
     Ok(Json(serde_json::to_value(result).unwrap()))
 }
 
@@ -669,8 +793,7 @@ async fn get_history(
     match session_id(&headers) {
         Some(sid) => {
             let _project = state.get_project_for_session(&sid)?;
-            let entries =
-                history::get_history(&state, &sid, limit).map_err(AppError::NotFound)?;
+            let entries = history::get_history(&state, &sid, limit).map_err(AppError::NotFound)?;
             Ok(Json(json!({ "history": entries, "count": entries.len() })))
         }
         None => {
@@ -692,7 +815,13 @@ async fn save_annotations(
     let project = require_project(&state, &headers)?;
     annotations::save_annotations(&project.root, &project.file_tree, &project.symbol_table)
         .map_err(AppError::Internal)?;
-    record_history(&state, session_id(&headers).as_deref(), "POST", "/annotations/save", "saved");
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "POST",
+        "/annotations/save",
+        "saved",
+    );
     Ok(Json(json!({ "ok": true })))
 }
 
@@ -701,18 +830,21 @@ async fn load_annotations(
     headers: HeaderMap,
 ) -> Result<Json<Value>, AppError> {
     let project = require_project(&state, &headers)?;
-    let data = annotations::load_annotations(
-        &project.root,
-        &project.file_tree,
-        &project.symbol_table,
-    )
-    .map_err(AppError::Internal)?;
+    let data =
+        annotations::load_annotations(&project.root, &project.file_tree, &project.symbol_table)
+            .map_err(AppError::Internal)?;
     let summary = json!({
         "file_definitions": data.file_definitions.len(),
         "file_marks": data.file_marks.len(),
         "symbol_definitions": data.symbol_definitions.len(),
     });
-    record_history(&state, session_id(&headers).as_deref(), "POST", "/annotations/load", "loaded");
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "POST",
+        "/annotations/load",
+        "loaded",
+    );
     Ok(Json(json!({ "ok": true, "loaded": summary })))
 }
 
@@ -740,8 +872,16 @@ async fn create_buffer(
         body.description.as_deref(),
     )
     .map_err(AppError::BadRequest)?;
-    record_history(&state, session_id(&headers).as_deref(), "POST", "/buffers", &body.name);
-    Ok(Json(json!({ "ok": true, "buffer": buf.name, "size": buf.content.len() })))
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "POST",
+        "/buffers",
+        &body.name,
+    );
+    Ok(Json(
+        json!({ "ok": true, "buffer": buf.name, "size": buf.content.len() }),
+    ))
 }
 
 #[derive(Deserialize)]
@@ -768,8 +908,16 @@ async fn buffer_from_file(
         body.end_line,
     )
     .map_err(AppError::BadRequest)?;
-    record_history(&state, session_id(&headers).as_deref(), "POST", "/buffers/from-file", &body.name);
-    Ok(Json(json!({ "ok": true, "buffer": buf.name, "size": buf.content.len() })))
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "POST",
+        "/buffers/from-file",
+        &body.name,
+    );
+    Ok(Json(
+        json!({ "ok": true, "buffer": buf.name, "size": buf.content.len() }),
+    ))
 }
 
 #[derive(Deserialize)]
@@ -794,8 +942,16 @@ async fn buffer_from_symbol(
         &body.file,
     )
     .map_err(AppError::BadRequest)?;
-    record_history(&state, session_id(&headers).as_deref(), "POST", "/buffers/from-symbol", &body.name);
-    Ok(Json(json!({ "ok": true, "buffer": buf.name, "size": buf.content.len() })))
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "POST",
+        "/buffers/from-symbol",
+        &body.name,
+    );
+    Ok(Json(
+        json!({ "ok": true, "buffer": buf.name, "size": buf.content.len() }),
+    ))
 }
 
 async fn list_buffers(
@@ -818,8 +974,7 @@ async fn get_buffer(
     axum::extract::Path(params): axum::extract::Path<BufferPath>,
 ) -> Result<Json<Value>, AppError> {
     let project = require_project(&state, &headers)?;
-    let buf = buffers::get_buffer(&project.buffers, &params.name)
-        .map_err(AppError::NotFound)?;
+    let buf = buffers::get_buffer(&project.buffers, &params.name).map_err(AppError::NotFound)?;
     Ok(Json(serde_json::to_value(buf).unwrap()))
 }
 
@@ -829,8 +984,7 @@ async fn delete_buffer(
     axum::extract::Path(params): axum::extract::Path<BufferPath>,
 ) -> Result<Json<Value>, AppError> {
     let project = require_project(&state, &headers)?;
-    buffers::delete_buffer(&project.buffers, &params.name)
-        .map_err(AppError::NotFound)?;
+    buffers::delete_buffer(&project.buffers, &params.name).map_err(AppError::NotFound)?;
     Ok(Json(json!({ "deleted": true })))
 }
 
@@ -871,7 +1025,13 @@ async fn set_var(
 ) -> Result<Json<Value>, AppError> {
     let project = require_project(&state, &headers)?;
     variables::set_var(&project.variables, &body.name, body.value);
-    record_history(&state, session_id(&headers).as_deref(), "POST", "/vars", &body.name);
+    record_history(
+        &state,
+        session_id(&headers).as_deref(),
+        "POST",
+        "/vars",
+        &body.name,
+    );
     Ok(Json(json!({ "ok": true })))
 }
 
@@ -895,8 +1055,7 @@ async fn get_var(
     axum::extract::Path(params): axum::extract::Path<VarPath>,
 ) -> Result<Json<Value>, AppError> {
     let project = require_project(&state, &headers)?;
-    let val = variables::get_var(&project.variables, &params.name)
-        .map_err(AppError::NotFound)?;
+    let val = variables::get_var(&project.variables, &params.name).map_err(AppError::NotFound)?;
     Ok(Json(json!({ "name": params.name, "value": val })))
 }
 
@@ -906,8 +1065,7 @@ async fn delete_var(
     axum::extract::Path(params): axum::extract::Path<VarPath>,
 ) -> Result<Json<Value>, AppError> {
     let project = require_project(&state, &headers)?;
-    variables::delete_var(&project.variables, &params.name)
-        .map_err(AppError::NotFound)?;
+    variables::delete_var(&project.variables, &params.name).map_err(AppError::NotFound)?;
     Ok(Json(json!({ "deleted": true })))
 }
 

--- a/server/src/server/state.rs
+++ b/server/src/server/state.rs
@@ -12,7 +12,7 @@ use crate::ops::buffers::Buffer;
 use crate::ops::subcalls::SubcallResult;
 use crate::server::errors::AppError;
 use crate::server::session::Session;
-use crate::symbols::{parser, SymbolTable};
+use crate::symbols::{SymbolTable, parser};
 
 /// A single indexed project with its own file tree, symbol table, and watcher.
 pub struct Project {
@@ -58,9 +58,9 @@ impl AppState {
 
     /// Look up an existing project or index a new one. Evicts LRU if at capacity.
     pub fn get_or_create_project(&self, cwd: &Path) -> Result<Arc<Project>, AppError> {
-        let canonical = cwd.canonicalize().map_err(|e| {
-            AppError::BadRequest(format!("Path not accessible: {}", e))
-        })?;
+        let canonical = cwd
+            .canonicalize()
+            .map_err(|e| AppError::BadRequest(format!("Path not accessible: {}", e)))?;
 
         if !canonical.is_dir() {
             return Err(AppError::BadRequest(format!(
@@ -86,19 +86,22 @@ impl AppState {
         let max_file_size = self.inner.max_file_size;
 
         info!("Indexing new project: {}", canonical.display());
-        let file_count =
-            walker::scan_directory(&canonical, &file_tree, max_file_size)
-                .map_err(|e| AppError::Internal(e.to_string()))?;
+        let file_count = walker::scan_directory(&canonical, &file_tree, max_file_size)
+            .map_err(|e| AppError::Internal(e.to_string()))?;
         info!("Indexed {} files for {}", file_count, canonical.display());
 
-        // Start watcher
-        let watcher_handle = watcher::start_watcher(
-            &canonical,
-            file_tree.clone(),
-            symbol_table.clone(),
-            max_file_size,
-        )
-        .ok();
+        // Start watcher unless disabled for large/generated-heavy workspaces.
+        let watcher_handle = if std::env::var("CODERLM_DISABLE_WATCHER").is_ok() {
+            None
+        } else {
+            watcher::start_watcher(
+                &canonical,
+                file_tree.clone(),
+                symbol_table.clone(),
+                max_file_size,
+            )
+            .ok()
+        };
 
         let project = Arc::new(Project {
             root: canonical.clone(),
@@ -139,17 +142,13 @@ impl AppState {
 
         let project_path = &session.project_path;
 
-        let project = self
-            .inner
-            .projects
-            .get(project_path)
-            .ok_or_else(|| {
-                AppError::Gone(format!(
-                    "Project at '{}' was evicted due to capacity limits. \
+        let project = self.inner.projects.get(project_path).ok_or_else(|| {
+            AppError::Gone(format!(
+                "Project at '{}' was evicted due to capacity limits. \
                      Start a new session to re-index, or increase --max-projects.",
-                    project_path.display()
-                ))
-            })?;
+                project_path.display()
+            ))
+        })?;
 
         Ok(project.clone())
     }
@@ -171,9 +170,7 @@ impl AppState {
             .min_by_key(|entry| *entry.value().last_active.lock())
             .map(|entry| entry.key().clone());
 
-        let path = oldest.ok_or_else(|| {
-            AppError::Internal("No projects to evict".into())
-        })?;
+        let path = oldest.ok_or_else(|| AppError::Internal("No projects to evict".into()))?;
 
         info!("Evicting project: {}", path.display());
 
@@ -181,7 +178,9 @@ impl AppState {
         self.inner.projects.remove(&path);
 
         // Remove all sessions attached to this project
-        self.inner.sessions.retain(|_, session| session.project_path != path);
+        self.inner
+            .sessions
+            .retain(|_, session| session.project_path != path);
 
         Ok(())
     }

--- a/server/src/symbols/parser.rs
+++ b/server/src/symbols/parser.rs
@@ -1,14 +1,14 @@
 use anyhow::Result;
 use std::path::Path;
 use std::sync::Arc;
-use tree_sitter::StreamingIterator;
 use tracing::{debug, warn};
+use tree_sitter::StreamingIterator;
 
 use crate::index::file_entry::Language;
 use crate::index::file_tree::FileTree;
+use crate::symbols::SymbolTable;
 use crate::symbols::queries;
 use crate::symbols::symbol::{Symbol, SymbolKind};
-use crate::symbols::SymbolTable;
 
 /// Extract symbols from a single file.
 pub fn extract_symbols_from_file(
@@ -39,7 +39,11 @@ pub fn extract_symbols_from_file(
     let mut cursor = tree_sitter::QueryCursor::new();
     let mut matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
 
-    let capture_names: Vec<String> = query.capture_names().iter().map(|s| s.to_string()).collect();
+    let capture_names: Vec<String> = query
+        .capture_names()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
 
     let mut symbols = Vec::new();
     let mut current_impl_type: Option<String> = None;
@@ -186,7 +190,10 @@ pub fn extract_symbols_from_file(
         use std::collections::HashMap;
         let kind_priority = |k: SymbolKind| -> u8 {
             match k {
-                SymbolKind::Other | SymbolKind::Variable | SymbolKind::Constant | SymbolKind::Import => 1,
+                SymbolKind::Other
+                | SymbolKind::Variable
+                | SymbolKind::Constant
+                | SymbolKind::Import => 1,
                 _ => 10,
             }
         };
@@ -195,7 +202,10 @@ pub fn extract_symbols_from_file(
             let key = format!("{}::{}", sym.file, sym.name);
             let range_size = sym.byte_range.1.saturating_sub(sym.byte_range.0);
             if let Some(&prev_idx) = best.get(&key) {
-                let prev_size = symbols[prev_idx].byte_range.1.saturating_sub(symbols[prev_idx].byte_range.0);
+                let prev_size = symbols[prev_idx]
+                    .byte_range
+                    .1
+                    .saturating_sub(symbols[prev_idx].byte_range.0);
                 if range_size > prev_size {
                     best.insert(key, i);
                 } else if range_size == prev_size

--- a/server/src/symbols/queries/elixir.rs
+++ b/server/src/symbols/queries/elixir.rs
@@ -1,0 +1,79 @@
+use super::{LanguageConfig, TestPattern};
+
+pub const SYMBOLS_QUERY: &str = r#"
+(call
+  target: (identifier) @ignore
+  (arguments (alias) @mod.name)
+  (#any-of? @ignore "defmodule" "defprotocol" "defimpl")) @mod.def
+
+(call
+  target: (identifier) @ignore
+  (arguments
+    [
+      (identifier) @function.name
+      (call target: (identifier) @function.name)
+      (binary_operator
+        left: (call target: (identifier) @function.name)
+        operator: "when")
+    ])
+  (#any-of? @ignore "def" "defp" "defdelegate" "defguard" "defguardp" "defmacro" "defmacrop" "defn" "defnp")) @function.def
+"#;
+
+pub const CALLERS_QUERY: &str = r#"
+(call
+  target: (identifier) @callee)
+
+(call
+  target: (dot
+    right: (identifier) @callee))
+
+(binary_operator
+  operator: "|>"
+  right: (identifier) @callee)
+
+(binary_operator
+  operator: "|>"
+  right: (call
+    target: (dot
+      right: (identifier) @callee)))
+"#;
+
+pub const VARIABLES_QUERY: &str = r#"
+(call
+  target: (identifier) @ignore
+  (arguments
+    (call
+      target: (identifier)
+      (arguments
+        (identifier) @var.name)))
+  (#any-of? @ignore "def" "defp" "defdelegate" "defguard" "defguardp" "defmacro" "defmacrop" "defn" "defnp"))
+
+(call
+  target: (identifier) @ignore
+  (arguments
+    (binary_operator
+      left: (call
+        target: (identifier)
+        (arguments
+          (identifier) @var.name))
+      operator: "when"))
+  (#any-of? @ignore "def" "defp" "defdelegate" "defguard" "defguardp" "defmacro" "defmacrop" "defn" "defnp"))
+
+(binary_operator
+  operator: "="
+  left: (identifier) @var.name)
+
+(binary_operator
+  operator: "<-"
+  left: (identifier) @var.name)
+"#;
+
+pub fn config() -> LanguageConfig {
+    LanguageConfig {
+        language: tree_sitter_elixir::LANGUAGE.into(),
+        symbols_query: SYMBOLS_QUERY,
+        callers_query: CALLERS_QUERY,
+        variables_query: VARIABLES_QUERY,
+        test_patterns: vec![TestPattern::CallExpression("test")],
+    }
+}

--- a/server/src/symbols/queries/mod.rs
+++ b/server/src/symbols/queries/mod.rs
@@ -1,3 +1,4 @@
+pub mod elixir;
 pub mod go;
 pub mod java;
 pub mod php;
@@ -20,6 +21,7 @@ pub fn get_language_config(lang: Language) -> Option<LanguageConfig> {
         Language::Go => Some(go::config()),
         Language::Java => Some(java::config()),
         Language::Scala => Some(scala::config()),
+        Language::Elixir => Some(elixir::config()),
         Language::Ruby => Some(ruby::config()),
         Language::Php => Some(php::config()),
         Language::Zig => Some(zig::config()),


### PR DESCRIPTION
## Summary
- add Elixir file detection, tree-sitter parser wiring, symbols, callers, variables, and ExUnit test discovery
- preserve upstream language support for Ruby, PHP, Zig, Java, Scala, Go, JS/TS, Python, and Rust
- refresh plugin docs and generated Codex/Cursor instruction assets with the combined supported-language list

## Validation
- cargo fmt
- cargo check
- cargo test
- live API smoke test against a temporary Elixir project covering symbol search, implementation lookup, variables, callers, and ExUnit test discovery